### PR TITLE
Patch plotting light

### DIFF
--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -160,6 +160,7 @@ def mcmc(args):
 
         print "Calculating uncertainties..."
         cpspost.uparams = {}
+        cpspost.medparams = {}
         for par in cpspost.params.keys():
             med = cps_quantile[par][0.5]
             high = cps_quantile[par][0.841] - med
@@ -168,6 +169,7 @@ def mcmc(args):
             err = radvel.utils.round_sig(err)
             med, err, errhigh = radvel.utils.sigfig(med, err)
             cpspost.uparams[par] = err
+            cpspost.medparams[par] = med
             
 
         print "Final loglikelihood = %f" % post.logprob()

--- a/radvel/plotting.py
+++ b/radvel/plotting.py
@@ -39,7 +39,7 @@ telfmts_default['apf'] = telfmts_default['a']
 telfmts_default['harps'] = telfmts_default['h']
 
 cmap = matplotlib.cm.nipy_spectral
-rcParams['font.size'] = 8
+rcParams['font.size'] = 9
 rcParams['lines.markersize'] = 5
 rcParams['axes.grid'] = False
     
@@ -283,7 +283,7 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
         scale = np.std(rawresid+rvmod)
         ax.set_ylim(-yscale_sigma * scale , yscale_sigma * scale)
 
-    ax.set_ylabel('RV [{ms:}]'.format(**latex))
+    ax.set_ylabel('RV [{ms:}]'.format(**latex), weight='bold')
     ticks = ax.yaxis.get_majorticklocs()
     ax.yaxis.set_ticks(ticks[1:])
 
@@ -309,8 +309,8 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
     ax.set_xlim(min(plttimes)-0.01*dt,max(plttimes)+0.01*dt)
     ax.yaxis.set_ticks([ticks[0],0.0,ticks[-1]])
     xticks = ax.xaxis.get_majorticklocs()
-    pl.xlabel('{} - {:d}'.format(latex['BJDTDB'],int(np.round(e))))
-    ax.set_ylabel('Residuals')
+    pl.xlabel('{} - {:d}'.format(latex['BJDTDB'],int(np.round(e))), weight='bold')
+    ax.set_ylabel('Residuals', weight='bold')
     ax.yaxis.set_major_locator(MaxNLocator(5,prune='both'))
     
     # Define the locations for the axes
@@ -373,8 +373,8 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
             ticks = ax.yaxis.get_majorticklocs()
             ax.yaxis.set_ticks(ticks[1:-1])
 
-        pl.ylabel('RV [{ms:}]'.format(**latex))
-        pl.xlabel('Phase')
+        pl.ylabel('RV [{ms:}]'.format(**latex), weight='bold')
+        pl.xlabel('Phase', weight='bold')
 
         print_params = ['per', 'k', 'e']
         units = {'per':'days','k':latex['ms'],'e':''}
@@ -384,20 +384,20 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
             val = cpsparams["%s%d" % (print_params[l],pnum)]
             
             if uparams is None:
-                _anotext = '%s = %4.2f %s' % (labels[l], val, units[p])
+                _anotext = '$\\mathregular{%s}$ = %4.2f %s' % (labels[l].replace("$",""), val, units[p])
             else:
                 err = uparams["%s%d" % (print_params[l],pnum)]
                 if err > 0:
                     val, err, errlow = radvel.utils.sigfig(val, err)
-                    _anotext = '%s = %s $\\pm$ %s %s' % (labels[l], val, err, units[p])
+                    _anotext = '$\\mathregular{%s}$ = %s $\\mathregular{\\pm}$ %s %s' % (labels[l].replace("$",""), val, err, units[p])
                 else:
-                    _anotext = '%s = %4.2f %s' % (labels[l], val, units[p])
+                    _anotext = '$\\mathregular{%s}$ = %4.2f %s' % (labels[l].replace("$",""), val, units[p])
 
             anotext += [_anotext] 
 
         anotext = '\n'.join(anotext)
         add_anchored(
-            anotext, loc=1, frameon=True, prop=dict(size='large'),
+            anotext, loc=1, frameon=True, prop=dict(size='large', weight='bold'),
             bbox=dict(ec='none', fc='w', alpha=0.8)
         )
 

--- a/radvel/plotting.py
+++ b/radvel/plotting.py
@@ -363,7 +363,6 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
         planetletter = letters[i+1]
         keys = [p+str(pnum) for p in ['per', 'k', 'e'] ]
         labels = [cpspost.params.tex_labels().get(k, k) for k in keys]
-        labels = ['P','K','e']
         if i < num_planets-1:
             ticks = ax.yaxis.get_majorticklocs()
             ax.yaxis.set_ticks(ticks[1:-1])
@@ -372,14 +371,14 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
         pl.xlabel('Phase')
 
         print_params = ['per', 'k', 'e']
-        units = {'per':'days','k':'m\ s^{-1}','e':''}
+        units = {'per':'days','k':latex['ms'],'e':''}
 
         anotext = []
         for l, p in enumerate(print_params):
             val = cpsparams["%s%d" % (print_params[l],pnum)]
             
             if uparams is None:
-                _anotext = '$\mathregular{{{:s}_{:s}\ =\ {:4.2f}\ {:s}}}$'.format(labels[l], planetletter, val, units[p])
+                _anotext = '%s = %4.2f %s' % (labels[l], val, units[p])
             else:
                 err = uparams["%s%d" % (print_params[l],pnum)]
                 if err > 0:
@@ -392,7 +391,7 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
 
         anotext = '\n'.join(anotext)
         add_anchored(
-            anotext, loc=1, frameon=True, prop=dict(size='large',weight='bold'),
+            anotext, loc=1, frameon=True, prop=dict(size='large'),
             bbox=dict(ec='none', fc='w', alpha=0.8)
         )
 

--- a/radvel/plotting.py
+++ b/radvel/plotting.py
@@ -137,7 +137,7 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
 
     """
     figwidth = 7.5 # spans a page with 0.5in margins
-    phasefac = 1.25
+    phasefac = 1.5
     ax_rv_height = figwidth * 1/2.
     ax_phase_height = ax_rv_height / phasefac
     bin_fac = 1.75
@@ -386,6 +386,13 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
             if uparams is None:
                 _anotext = '$\\mathregular{%s}$ = %4.2f %s' % (labels[l].replace("$",""), val, units[p])
             else:
+                if hasattr(post, 'medparams'):
+                    val = post.medparams["%s%d" % (print_params[l],pnum)]
+                else:
+                    print "WARNING: medparams attribute not found in "+ \
+                          "posterior object will annotate with "+ \
+                          "max-likelihood values and reported uncertainties "+ \
+                          "may not be appropriate."
                 err = uparams["%s%d" % (print_params[l],pnum)]
                 if err > 0:
                     val, err, errlow = radvel.utils.sigfig(val, err)


### PR DESCRIPTION
Made some further tweaks to the plotting. There's a light background to help the labels stand out and the label sizes are a little bigger.

![image](https://cloud.githubusercontent.com/assets/694371/18753841/724cdbfc-809b-11e6-98ba-5df6b5472ef6.png)

![image](https://cloud.githubusercontent.com/assets/694371/18753849/79a060b8-809b-11e6-833e-2e041f02166e.png)

Also, if you like bold labels, there's this option:
![image](https://cloud.githubusercontent.com/assets/694371/18753952/ca1abe1c-809b-11e6-9820-3f6a5dbd3769.png)

![image](https://cloud.githubusercontent.com/assets/694371/18753959/d0d9a27c-809b-11e6-9562-6f14ecb47a0b.png)

The code is in  `patch-plotting-bold`
