### PR TITLE
added ability to specify path to latex compiler

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,8 @@ Installation Instructions
 =========================
 
 1. Install dependencies: `emcee`, `corner`, `pandas`,
-   `matplotlib-1.5.1`, `cython (tested with 0.22)`, `astropy`, `pdflatex` (installed and in your system's path)
+   `matplotlib-1.5.1`, `cython (tested with 0.22)`, `astropy`,
+   `pdflatex`
 2. Download ``radvel`` from git repo
 3. Run ``python setup.py install`` from within the main repo directory
 

--- a/docs/quickstartcli.rst
+++ b/docs/quickstartcli.rst
@@ -10,15 +10,18 @@ Installation
 
 Install python dependencies: `emcee`, `corner`, `pandas`,
 `matplotlib`, `cython (tested with 0.22)`, `astropy`,
-`pdflatex` (installed and in your system's path):
+`pdflatex`:
 
 .. code-block:: bash
 
     $ pip install emcee corner pandas matplotlib cython astropy
 
-Make sure that ``pdflatex`` is installed and in your system's
-path. You can get ``pdflatex`` by installing the `TexLive package
+Make sure that ``pdflatex`` is installed. 
+You can get ``pdflatex`` by installing the `TexLive package
 <https://www.tug.org/texlive/>`_ or other LaTeX distributions.
+By default it is expected to be in your system's path, but you may
+specify a path to pdflatex using the ``--latex-compiler``
+option at the ``radvel report`` step.
 
 If ``git`` is installed on your system then clone the repository:
 

--- a/radvel/cli.py
+++ b/radvel/cli.py
@@ -118,7 +118,7 @@ def main():
         Default: nplanets')
 
     psr_report.add_argument(
-        '--latex-compiler', default=None, type=str, 
+        '--latex-compiler', default='pdflatex', type=str, 
         help='Path to latex compiler'
         )
 

--- a/radvel/cli.py
+++ b/radvel/cli.py
@@ -115,7 +115,12 @@ def main():
         '--comptype', dest='comptype', action='store',
         default='nplanets', type=str, 
         help='Type of BIC model comparison table to include. \
-Default: nplanets')
+        Default: nplanets')
+
+    psr_report.add_argument(
+        '--latex-compiler', default=None, type=str, 
+        help='Path to latex compiler'
+        )
 
     psr_report.set_defaults(func=radvel.driver.report)
     

--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -412,7 +412,9 @@ like to include\nthe model comparison table in the report.".format(args.comptype
     with radvel.utils.working_directory(args.outputdir):
         rfile = os.path.join(conf_base+"_results.pdf")
         report_depfiles = [os.path.basename(p) for p in report_depfiles]
-        report.compile(rfile, depfiles=report_depfiles)
+        report.compile(
+            rfile, depfiles=report_depfiles, latex_compiler=args.latex_compiler
+        )
 
     
 def save_status(statfile, section, statevars):


### PR DESCRIPTION
Added the ability to specify the path of pdflatex by the command line. On my machine, TeXShop installs  pdflatex as 

`/Applications/TeX/TeXShop.app/Contents/Resources/TeXShop/bin/pdflatexc`

aliases don't play nicely with subprocess. 

```
radvel report -s <setup-file> --latex-compiler=/Applications/TeX/TeXShop.app/Contents/Resources/TeXShop/bin/pdflatexc
``` 
