### PR TITLE
removing omega degrees conversion

### DIFF
--- a/radvel/basis.py
+++ b/radvel/basis.py
@@ -218,11 +218,6 @@ class Basis(object):
                 e = _getpar('e')
                 w = _getpar('w')
                 k = _getpar('k')
-                if w > 2 * np.pi:
-                    print "switching from degrees to radians"
-                    w *= np.pi/180
-                else:
-                    print "w=",w, "(radians)"
                 try:
                     tp = _getpar('tp')
                 except KeyError:


### PR DESCRIPTION
Omega should always be in radians everywhere.