### PR TITLE
MAJOR RELEASE: Changed MCMC convergence criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RadVel
 
-General Toolkit for Modeling Radial Velocities. Version 0.8.4
+General Toolkit for Modeling Radial Velocities. Version 0.9.0
 
 ## Attribution
 

--- a/radvel/__init__.py
+++ b/radvel/__init__.py
@@ -11,7 +11,7 @@ from .fitting import *
 import os 
 import sys
 
-__version__ = '0.8.5'
+__version__ = '0.9.0'
 
 MODULEDIR, filename = os.path.split(__file__)
 DATADIR = os.path.join(sys.prefix,'radvel_example_data')

--- a/radvel/basis.py
+++ b/radvel/basis.py
@@ -10,6 +10,7 @@ BASIS_NAMES = [
 'per tp e w k', # The CPS basis
 'per tc secosw sesinw logk',
 'per tc secosw sesinw k',
+'per tc ecosw esinw k',
 'per tc e w k'
 
 ]
@@ -46,6 +47,7 @@ class Basis(object):
         'per tp e w k' (The CPS basis) \n
         'per tc secosw sesinw logk'  \n 
         'per tc secosw sesinw k'  \n
+        'per tc ecosw esinw k'  \n
         'per tc e w k'
     """
     
@@ -145,6 +147,19 @@ class Basis(object):
                 # transform into CPS basis
                 e = secosw**2 + sesinw**2
                 w = np.arctan2(sesinw , secosw)
+                tp = timetrans_to_timeperi(tc, per, e, w)
+
+            if basis_name=='per tc ecosw esinw k':
+                # pull out parameters
+                per = _getpar('per')
+                tc = _getpar('tc')
+                ecosw = _getpar('ecosw')
+                esinw = _getpar('esinw')
+                k = _getpar('k')
+            
+                # transform into CPS basis
+                e = np.sqrt(ecosw**2 + esinw**2)
+                w = np.arctan2(esinw , ecosw)
                 tp = timetrans_to_timeperi(tc, per, e, w)
 
                                 
@@ -259,6 +274,30 @@ class Basis(object):
 
                 self.name = newbasis
                 self.params = newbasis.split()
+
+            if newbasis == 'per tc ecosw esinw k':
+                per = _getpar('per')
+                e = _getpar('e')
+                w = _getpar('w')
+                k = _getpar('k')
+                try:
+                    tp = _getpar('tp')
+                except KeyError:
+                    tp = timetrans_to_timeperi(_getpar('tc'), per, e, w)
+                    _setpar('tp', tp)
+                _setpar('ecosw', e*np.cos(w) )
+                _setpar('esinw', e*np.sin(w) )
+                _setpar('k', k )
+                _setpar('tc', timeperi_to_timetrans(tp, per, e, w) )
+
+                if not kwargs.get('keep', True):
+                    _delpar('tp')
+                    _delpar('e')
+                    _delpar('w')
+
+                self.name = newbasis
+                self.params = newbasis.split()
+
 
         params_out.basis = Basis(newbasis, self.num_planets)
                 

--- a/radvel/basis.py
+++ b/radvel/basis.py
@@ -86,6 +86,8 @@ class Basis(object):
 
         """
 
+        basis_name = kwargs.setdefault('basis_name', self.name)
+
         if isinstance(params_in,pd.core.frame.DataFrame):
             # Output by emcee
             params_out = params_in.copy()
@@ -103,7 +105,7 @@ class Basis(object):
                     params_out.drop('{}{}'.format(key,num_planet))
 
             # transform into CPS basis
-            if self.name == 'per tp e w k':
+            if basis_name == 'per tp e w k':
                 # already in the CPS basis
                 per = _getpar('per')
                 tp = _getpar('tp')
@@ -111,7 +113,7 @@ class Basis(object):
                 w = _getpar('w')   
                 k = _getpar('k')
                 
-            if self.name == 'per tc e w k':
+            if basis_name == 'per tc e w k':
                 per = _getpar('per')
                 tc = _getpar('tc')
                 e = _getpar('e')
@@ -119,7 +121,7 @@ class Basis(object):
                 k = _getpar('k')
                 tp = timetrans_to_timeperi(tc, per, e, w)
             
-            if self.name=='per tc secosw sesinw logk':
+            if basis_name=='per tc secosw sesinw logk':
                 # pull out parameters
                 per = _getpar('per')
                 tc = _getpar('tc')
@@ -132,7 +134,7 @@ class Basis(object):
                 w = np.arctan2(sesinw , secosw)
                 tp = timetrans_to_timeperi(tc, per, e, w)
 
-            if self.name=='per tc secosw sesinw k':
+            if basis_name=='per tc secosw sesinw k':
                 # pull out parameters
                 per = _getpar('per')
                 tc = _getpar('tc')
@@ -231,7 +233,7 @@ class Basis(object):
                     _delpar('w')
                     _delpar('k')
 
-                self.name = newbasis
+                basis_name = newbasis
                 self.params = newbasis.split()
 
                 

--- a/radvel/basis.py
+++ b/radvel/basis.py
@@ -1,7 +1,8 @@
 import numpy as np        
-import copy
+from collections import OrderedDict
 import pandas as pd
 from orbit import timeperi_to_timetrans, timetrans_to_timeperi
+import radvel.model
 
 # List of available bases
 BASIS_NAMES = [
@@ -15,6 +16,15 @@ BASIS_NAMES = [
 def _print_valid_basis():
     print "Available bases:"
     print "\n".join(BASIS_NAMES)
+
+def _copy_params(params_in, new_basis):
+    params_out = radvel.model.RVParameters(
+    params_in.num_planets, basis=new_basis,
+    planet_letterrs=params_in.planet_letters)
+    
+    params_out.update(params_in)
+    
+    return params_out
 
 class Basis(object):
     """
@@ -72,14 +82,15 @@ class Basis(object):
 
         """
 
-        params_out = copy.copy(params_in)
+        params_out = params_in.copy()
+        #import pdb; pdb.set_trace()
         for num_planet in range(1,1+self.num_planets):
             def _getpar(key):
                 return params_out['{}{}'.format(key,num_planet)]
             def _setpar(key, value):
                 params_out['{}{}'.format(key,num_planet)] = value
             def _delpar(key):
-                if isinstance(params_in,dict):
+                if isinstance(params_in,OrderedDict):
                     del params_out['{}{}'.format(key,num_planet)]
                 elif isinstance(params_in,pd.core.frame.DataFrame):
                     params_out.drop('{}{}'.format(key,num_planet))
@@ -160,7 +171,7 @@ class Basis(object):
             _print_valid_basis()
             return None
         
-        params_out = copy.copy(params_in)
+        params_out = params_in.copy()
         for num_planet in range(1,1+self.num_planets):
             def _getpar(key):
                 return params_out['{}{}'.format(key,num_planet)]

--- a/radvel/cli.py
+++ b/radvel/cli.py
@@ -76,6 +76,12 @@ def main():
         '--nwalkers', dest='nwalkers', action='store', default=50, type=int,
         help='Number of walkers. [50]', 
     )
+    psr_mcmc.add_argument(
+    '--nensembles', dest='ensembles', action='store', default=8, type=int,
+    help='''\
+Number of ensembles. Will be run in parallel on separate CPUs [8]
+'''
+    )
     psr_mcmc.set_defaults(func=radvel.driver.mcmc)
 
 

--- a/radvel/cli.py
+++ b/radvel/cli.py
@@ -70,8 +70,8 @@ def main():
         description="Perform MCMC exploration"
     )
     psr_mcmc.add_argument(
-        '--nsteps', dest='nsteps', action='store',default=20000, type=float, 
-        help='Number of steps per chain [20000]',)
+        '--nsteps', dest='nsteps', action='store',default=10000, type=float, 
+        help='Number of steps per chain [10000]',)
     psr_mcmc.add_argument(
         '--nwalkers', dest='nwalkers', action='store', default=50, type=int,
         help='Number of walkers. [50]', 

--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -133,7 +133,7 @@ def mcmc(args):
     print msg
 
     chains = radvel.mcmc(
-        post, threads=1, nwalkers=args.nwalkers, nrun=args.nsteps
+        post, nwalkers=args.nwalkers, nrun=args.nsteps, ensembles=args.ensembles
     )
 
 
@@ -204,7 +204,8 @@ def mcmc(args):
                  'nsteps': args.nsteps}
     save_status(statfile, 'mcmc', savestate)
 
-
+    os._exit(0)
+    
 def bic(args):
     """Compare different models and comparative statistics
 

--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -95,11 +95,11 @@ def fit(args):
 
     P, post = radvel.utils.initialize_posterior(config_file, decorr=args.decorr)
     post = radvel.fitting.maxlike_fitting(post, verbose=True)
-
+    
     postfile = os.path.join(args.outputdir,
                             '{}_post_obj.pkl'.format(conf_base))
     post.writeto(postfile)
-
+    
     savestate = {'run': True,
                  'postfile': os.path.abspath(postfile)}
     save_status(os.path.join(args.outputdir,
@@ -127,7 +127,6 @@ def mcmc(args):
     else:
         P, post = radvel.utils.initialize_posterior(config_file, decorr=args.decorr)
 
-
     msg = "Running MCMC for {}, nwalkers = {}, nsteps = {} ...".format(
         conf_base, args.nwalkers, args.nsteps)
     print msg
@@ -140,7 +139,7 @@ def mcmc(args):
     # Convert chains into CPS basis
     cpschains = chains.copy()
     for par in post.params.keys():
-        if not post.vary[par]:
+        if par in post.vary.keys() and not post.vary[par]:
             cpschains[par] = post.params[par]
 
     cpschains = post.params.basis.to_cps(cpschains)

--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -125,14 +125,16 @@ def mcmc(args):
 
         post = radvel.posterior.load(status.get('fit', 'postfile'))
     else:
-        P, post = radvel.utils.initialize_posterior(config_file, decorr=args.decorr)
+        P, post = radvel.utils.initialize_posterior(config_file,
+                                                        decorr=args.decorr)
 
-    msg = "Running MCMC for {}, nwalkers = {}, nsteps = {} ...".format(
-        conf_base, args.nwalkers, args.nsteps)
+    msg = "Running MCMC for {}, N_ensembles = {}, N_walkers = {}, N_steps = {} ...".format(
+        conf_base, args.ensembles, args.nwalkers, args.nsteps)
     print msg
 
     chains = radvel.mcmc(
-        post, nwalkers=args.nwalkers, nrun=args.nsteps, ensembles=args.ensembles
+        post, nwalkers=args.nwalkers, nrun=args.nsteps,
+        ensembles=args.ensembles
     )
 
 

--- a/radvel/fitting.py
+++ b/radvel/fitting.py
@@ -16,21 +16,22 @@ def maxlike_fitting(post, verbose=True):
         updated their maximum likelihood values
 
     """
-    
-    post0 = post.copy()
+
+    post0 = copy.copy(post)
     if verbose:
         print "Initial loglikelihood = %f" % post0.logprob()
         print "Performing maximum likelihood fit..."
 
+        
     res  = optimize.minimize(
         post.neglogprob_array, post.get_vary_params(), method='Powell',
         options=dict(maxiter=100,maxfev=100000,xtol=1e-8)
     )
 
-    cpspost = copy.deepcopy(post)
+    cpspost = copy.copy(post)
     cpsparams = post.params.basis.to_cps(post.params)
     cpspost.params.update(cpsparams)
-
+    
     if verbose:
         print "Final loglikelihood = %f" % post.logprob()
         print "Best-fit parameters:"
@@ -58,7 +59,7 @@ def model_comp(post, verbose=False):
             of that statistic in the second element.
     """
 
-    ipost = copy.deepcopy(post)
+    ipost = copy.copy(post)
         
     num_planets = post.likelihood.model.num_planets
 

--- a/radvel/fitting.py
+++ b/radvel/fitting.py
@@ -17,7 +17,7 @@ def maxlike_fitting(post, verbose=True):
 
     """
     
-    post0 = copy.deepcopy(post)
+    post0 = post.copy()
     if verbose:
         print "Initial loglikelihood = %f" % post0.logprob()
         print "Performing maximum likelihood fit..."

--- a/radvel/likelihood.py
+++ b/radvel/likelihood.py
@@ -70,6 +70,24 @@ class Likelihood(object):
                 
         return s
 
+    def copy(self):
+        model = self.model.copy()
+        x = self.x
+        y = self.y
+        yerr = self.yerr
+        extra_params = self.extra_params
+        decorr_params = self.decorr_params
+        decorr_vectors = self.decorr_vectors
+        
+        new = Likelihood(model, x, y, yerr, extra_params=extra_params,
+                             decorr_params=decorr_params,
+                             decorr_vectors=decorr_vectors)
+
+        print self.vary
+        new.vary = self.vary
+        
+        return new
+    
     def set_vary_params(self, params_array):
         i = 0
         for key in self.list_vary_params():
@@ -87,6 +105,7 @@ class Likelihood(object):
         params_array = []
         for key in self.params.keys():
             if self.vary[key]:
+                print key, self.params[key]
                 params_array += [ self.params[key] ]
                 
         params_array = np.array(params_array)
@@ -133,6 +152,8 @@ class CompositeLikelihood(Likelihood):
         self.yerr = like0.yerr
         self.telvec = like0.telvec
         self.extra_params = like0.extra_params
+        #self.decorr_params = like0.decorr_params
+        #self.decorr_vectors = like0.decorr_vectors
         self.suffixes = like0.suffix
         self.uparams = like0.uparams
         
@@ -145,6 +166,8 @@ class CompositeLikelihood(Likelihood):
             self.yerr = np.append(self.yerr, like.yerr)
             self.telvec = np.append(self.telvec, like.telvec)
             self.extra_params = np.append(self.extra_params, like.extra_params)
+            #self.decorr_params = np.append(self.decorr_params, like.decorr_params)
+            #self.decorr_vectors = np.append(self.decorr_vectors, like.decorr_vectors)
             self.suffixes = np.append(self.suffixes, like.suffix)
             try:
                 self.uparams = self.uparams.update(like.uparams)
@@ -166,6 +189,11 @@ class CompositeLikelihood(Likelihood):
         self.vary = {}.fromkeys(params.keys(),True)
         self.like_list = like_list
 
+    def copy(self):
+        comp = CompositeLikelihood(self.like_list)
+
+        return comp
+        
     def logprob(self):
         """
         See `radvel.likelihood.RVLikelihood.logprob`
@@ -306,6 +334,7 @@ def loglike_jitter(residuals, sigma, sigma_jit):
     sum_sig_quad = sigma**2 + sigma_jit**2
     penalty = np.sum( np.log( np.sqrt( 2 * np.pi * sum_sig_quad ) ) )
     chi2 = np.sum(residuals**2 / sum_sig_quad)
-    loglike = -0.5 * chi2 - penalty 
+    loglike = -0.5 * chi2 - penalty
+    
     return loglike
 

--- a/radvel/likelihood.py
+++ b/radvel/likelihood.py
@@ -26,8 +26,10 @@ class Likelihood(object):
                 'parameter', 'value', 'vary'
                 )
             keys = self.params.keys()
-            keys.sort()
+            #keys.sort()
             for key in keys:
+                if key == 'meta':
+                    continue
                 if key in self.vary.keys():
                     vstr = str(self.vary[key])
                 else:
@@ -47,8 +49,10 @@ class Likelihood(object):
                 'parameter', 'value', '+/-', 'vary'
                 )
             keys = self.params.keys()
-            keys.sort()
+            #keys.sort()
             for key in keys:
+                if key == 'meta':
+                    continue
                 if key in self.vary.keys():
                     vstr = str(self.vary[key])
                 else:
@@ -70,23 +74,6 @@ class Likelihood(object):
                 
         return s
 
-    def copy(self):
-        model = self.model.copy()
-        x = self.x
-        y = self.y
-        yerr = self.yerr
-        extra_params = self.extra_params
-        decorr_params = self.decorr_params
-        decorr_vectors = self.decorr_vectors
-        
-        new = Likelihood(model, x, y, yerr, extra_params=extra_params,
-                             decorr_params=decorr_params,
-                             decorr_vectors=decorr_vectors)
-
-        print self.vary
-        new.vary = self.vary
-        
-        return new
     
     def set_vary_params(self, params_array):
         i = 0
@@ -103,16 +90,16 @@ class Likelihood(object):
 
     def get_vary_params(self):
         params_array = []
-        for key in self.params.keys():
-            if self.vary[key]:
-                print key, self.params[key]
+        for key in self.list_vary_params():
+            if key != 'meta' and self.vary[key]:
                 params_array += [ self.params[key] ]
                 
         params_array = np.array(params_array)
         return params_array
 
     def list_vary_params(self):
-        return [key for key in self.params if self.vary[key] ]
+        return [key for key in self.params.keys() if key != 'meta'
+                    and key in self.vary.keys() and self.vary[key] ]
 
     def residuals(self):
         return self.y - self.model(self.x) 
@@ -188,11 +175,6 @@ class CompositeLikelihood(Likelihood):
         self.params = params
         self.vary = {}.fromkeys(params.keys(),True)
         self.like_list = like_list
-
-    def copy(self):
-        comp = CompositeLikelihood(self.like_list)
-
-        return comp
         
     def logprob(self):
         """

--- a/radvel/mcmc.py
+++ b/radvel/mcmc.py
@@ -96,8 +96,10 @@ def mcmc(likelihood, nwalkers=50, nrun=10000, ensembles=8,
             # if less than 3 ensembles then GR between ensembles does
             # not work so just calculate is on the last sampler
             tchains = sampler.chain.transpose()
-            
-        if pcomplete < 5 and sampler.flatlnprobability.shape[0] <= 500*nwalkers:
+
+        # Must have compelted at least 5% or 1000 steps per walker before
+        # attempting to calculate GR
+        if pcomplete < 5 and sampler.flatlnprobability.shape[0] <= 1000*nwalkers:
             (ismixed, maxgr, mintz) = 0, np.inf, -1
         else:
             (ismixed, gr, tz) = gelman_rubin(tchains)

--- a/radvel/mcmc.py
+++ b/radvel/mcmc.py
@@ -19,7 +19,7 @@ maxGR = 1.01
 
 # Minimum number of steps per walker before
 # convergence tests are performed
-minsteps = 100
+minsteps = 1000
 
 class StateVars(object):
     def __init__(self):
@@ -225,6 +225,8 @@ def mcmc(likelihood, nwalkers=50, nrun=10000, ensembles=8,
             statevars.burn_complete = True
 
         if statevars.mixcount >= 5:
+            server.wait()
+            ch.join()
             tf = time.time()
             tdiff = tf - statevars.t0
             tdiff,units = utils.time_print(tdiff)

--- a/radvel/mcmc.py
+++ b/radvel/mcmc.py
@@ -19,7 +19,7 @@ maxGR = 1.01
 
 # Minimum number of steps per walker before
 # convergence tests are performed
-minsteps = 1000
+minsteps = 100
 
 class StateVars(object):
     def __init__(self):
@@ -140,12 +140,12 @@ def mcmc(likelihood, nwalkers=50, nrun=10000, ensembles=8,
     for par in likelihood.list_vary_params():
         val = likelihood.params[par]
         if par.startswith('per'):
-            pscale = np.abs(val * 0.001*np.log10(val))
+            pscale = np.abs(val * 1e-5*np.log10(val))
             pscale_per = pscale
         elif par.startswith('tc'):
             pscale = pscale_per
         else:
-            pscale = np.abs(0.25 * val)
+            pscale = np.abs(0.10 * val)
 
         pscales.append(pscale)
         

--- a/radvel/mcmc.py
+++ b/radvel/mcmc.py
@@ -17,6 +17,9 @@ burnGR = 1.03
 # Maximum G-R statistic for chains to be deemed well-mixed
 maxGR = 1.01
 
+# Minimum number of steps per walker before
+# convergence tests are performed
+minsteps = 1000
 
 class StateVars(object):
     def __init__(self):
@@ -24,70 +27,6 @@ class StateVars(object):
 
 statevars = StateVars()
 
-
-def convergence_check(server, samplers):
-
-
-    
-    ar = 0
-    statevars.ncomplete = statevars.nburn
-    statevars.tchains = np.empty((statevars.ndim,
-                        statevars.samplers[0].flatlnprobability.shape[0],
-                        statevars.ensembles))
-    statevars.lnprob = []
-    for i,sampler in enumerate(statevars.samplers):
-        statevars.ncomplete += sampler.flatlnprobability.shape[0]
-        ar += sampler.acceptance_fraction.mean() * 100
-        statevars.tchains[:,:,i] = sampler.flatchain.transpose()
-        statevars.lnprob.append(sampler.flatlnprobability)
-    ar /= statevars.ensembles
-
-    pcomplete = statevars.ncomplete/float(statevars.totsteps) * 100
-    rate = (statevars.checkinterval*statevars.nwalkers*statevars.ensembles) / statevars.interval
-
-    if statevars.ensembles < 3:
-        # if less than 3 ensembles then GR between ensembles does
-        # not work so just calculate is on the last sampler
-        statevars.tchains = sampler.chain.transpose()
-
-    # Must have compelted at least 5% or 1000 steps per walker before
-    # attempting to calculate GR
-    if pcomplete < 5 and sampler.flatlnprobability.shape[0] <= 300*statevars.nwalkers:
-        (statevars.ismixed, maxgr, mintz) = 0, np.inf, -1
-    else:
-        (statevars.ismixed, gr, tz) = gelman_rubin(statevars.tchains)
-        mintz = min(tz)
-        maxgr = max(gr)
-        if statevars.ismixed:
-            statevars.mixcount += 1
-        else:
-            statevars.mixcount = 0
-
-    # Burn-in complete after maximum G-R statistic first reaches burnGR
-    # reset sampler
-    if not statevars.burn_complete and maxgr <= burnGR:
-        for sampler in samplers:
-            statevars.initial_positions[i] = sampler._last_run_mcmc_result[0]
-            sampler.reset()
-        msg = (
-            "\nDiscarding burn-in now that the chains are marginally "
-            "well-mixed\n"
-        )
-        print msg
-        statevars.nburn = statevars.ncomplete
-        statevars.burn_complete = True
-
-    else:
-        msg = (
-            "{:d}/{:d} ({:3.1f}%) steps complete; "
-            "Running {:.2f} steps/s; Mean acceptance rate = {:3.1f}%; "
-            "Min Tz = {:.1f}; Max G-R = {:4.2f}      \r"
-        ).format(statevars.ncomplete, statevars.totsteps, pcomplete, rate, ar, mintz, maxgr)
-
-        sys.stdout.write(msg)
-        sys.stdout.flush()
-
-        
 class CheckThread(threading.Thread):
     def __init__(self, target, *args):
         self._target = target
@@ -96,10 +35,70 @@ class CheckThread(threading.Thread):
 
     def run(self):
         self._target(*self._args)
+
+
+def _status_message(statevars):
+    msg = (
+        "{:d}/{:d} ({:3.1f}%) steps complete; "
+        "Running {:.2f} steps/s; Mean acceptance rate = {:3.1f}%; "
+        "Min Tz = {:.1f}; Max G-R = {:4.2f}      \r"
+    ).format(statevars.ncomplete, statevars.totsteps, statevars.pcomplete,
+                 statevars.rate, statevars.ar, statevars.mintz, statevars.maxgr)
+
+    sys.stdout.write(msg)
+    sys.stdout.flush()
+
+
+def convergence_check(server, samplers):
+    """Check for convergence
+
+    Check for convergence for a list of running emcee samplers
     
+    Args:
+        server (pp.server): Parallel Python server object running the
+            samplers
+        samplers (list): List of emcee sampler objects
+    """
+    
+    statevars.ar = 0
+    statevars.ncomplete = statevars.nburn
+    statevars.tchains = np.empty((statevars.ndim,
+                        statevars.samplers[0].flatlnprobability.shape[0],
+                        statevars.ensembles))
+    statevars.lnprob = []
+    for i,sampler in enumerate(statevars.samplers):
+        statevars.ncomplete += sampler.flatlnprobability.shape[0]
+        statevars.ar += sampler.acceptance_fraction.mean() * 100
+        statevars.tchains[:,:,i] = sampler.flatchain.transpose()
+        statevars.lnprob.append(sampler.flatlnprobability)
+    statevars.ar /= statevars.ensembles
+
+    statevars.pcomplete = statevars.ncomplete/float(statevars.totsteps) * 100
+    statevars.rate = (statevars.checkinterval*statevars.nwalkers*statevars.ensembles) / statevars.interval
+
+    if statevars.ensembles < 3:
+        # if less than 3 ensembles then GR between ensembles does
+        # not work so just calculate is on the last sampler
+        statevars.tchains = sampler.chain.transpose()
+
+    # Must have compelted at least 5% or 1000 steps per walker before
+    # attempting to calculate GR
+    if statevars.pcomplete < 10 and sampler.flatlnprobability.shape[0] <= minsteps*statevars.nwalkers:
+        (statevars.ismixed, statevars.maxgr, statevars.mintz) = 0, np.inf, -1
+    else:
+        (statevars.ismixed, gr, tz) = gelman_rubin(statevars.tchains)
+        statevars.mintz = min(tz)
+        statevars.maxgr = max(gr)
+        if statevars.ismixed:
+            statevars.mixcount += 1
+        else:
+            statevars.mixcount = 0
+
+    _status_message(statevars)
+
 
 def mcmc(likelihood, nwalkers=50, nrun=10000, ensembles=8,
-             checkinterval=30):
+             checkinterval=50):
     """Run MCMC
 
     Run MCMC chains using the emcee EnsambleSampler
@@ -141,12 +140,12 @@ def mcmc(likelihood, nwalkers=50, nrun=10000, ensembles=8,
     for par in likelihood.list_vary_params():
         val = likelihood.params[par]
         if par.startswith('per'):
-            pscale = np.abs(val * 0.01*np.log10(val))
+            pscale = np.abs(val * 0.001*np.log10(val))
             pscale_per = pscale
         elif par.startswith('tc'):
             pscale = pscale_per
         else:
-            pscale = np.abs(0.10 * val)
+            pscale = np.abs(0.25 * val)
 
         pscales.append(pscale)
         
@@ -168,9 +167,18 @@ def mcmc(likelihood, nwalkers=50, nrun=10000, ensembles=8,
     num_run = int(np.round(nrun / checkinterval))
     statevars.totsteps = nrun*statevars.nwalkers*statevars.ensembles
     statevars.mixcount = 0
+    statevars.ismixed = 0
     statevars.burn_complete = False
     statevars.nburn = 0
+    statevars.ncomplete = statevars.nburn
+    statevars.pcomplete = 0
+    statevars.rate = 0
+    statevars.ar = 0
+    statevars.mintz = -1
+    statevars.maxgr = np.inf
     statevars.t0 = time.time()
+
+    
     for r in range(num_run):
         t1 = time.time()
         jobs = []
@@ -187,17 +195,35 @@ def mcmc(likelihood, nwalkers=50, nrun=10000, ensembles=8,
         t2 = time.time()
         statevars.interval = t2 - t1
 
+        # Use Threading
         ch = CheckThread(convergence_check, statevars.server, statevars.samplers)
         ch.start()
 
+        # Use multiprocessing
         # result = pool.apply_async(convergence_check,
-        #                     (server, samplers,
-        #                       interval, burn_complete, nburn, mixcount,
-        #                       totsteps, checkinterval, initial_positions))
-        # print result.get()
+        #                 (statevars.server, statevars.samplers))
 
-        #convergence_check(statevars.server, statevars.samplers)
+        # ch = CheckThread(status_message, statevars)
+        # ch.start()
         
+        #convergence_check(statevars.server, statevars.samplers)
+        # Burn-in complete after maximum G-R statistic first reaches burnGR
+        # reset samplers
+        if not statevars.burn_complete and statevars.maxgr <= burnGR:
+            server.wait()
+            ch.join()
+            for i, sampler in enumerate(statevars.samplers):
+                statevars.initial_positions[i] = sampler._last_run_mcmc_result[0]
+                sampler.reset()
+                statevars.samplers[i] = sampler
+            msg = (
+                "\nDiscarding burn-in now that the chains are marginally "
+                "well-mixed\n"
+            )
+            print(msg)
+            statevars.nburn = statevars.ncomplete
+            statevars.burn_complete = True
+
         if statevars.mixcount >= 5:
             tf = time.time()
             tdiff = tf - statevars.t0
@@ -206,24 +232,24 @@ def mcmc(likelihood, nwalkers=50, nrun=10000, ensembles=8,
                 "\nChains are well-mixed after {:d} steps! MCMC completed in "
                 "{:3.1f} {:s}"
             ).format(statevars.ncomplete, tdiff, units)
-            print msg
+            print(msg)
             break
 
     server.destroy()
             
-    print "\n"        
+    print("\n")        
     if statevars.ismixed and statevars.mixcount < 5: 
         msg = (
             "MCMC: WARNING: chains did not pass 5 consecutive convergence "
             "tests. They may be marginally well=mixed."
         )
-        print msg
+        print(msg)
     elif not statevars.ismixed: 
         msg = (
             "MCMC: WARNING: chains did not pass convergence tests. They are "
             "likely not well-mixed."
         )
-        print msg
+        print(msg)
         
     df = pd.DataFrame(
         statevars.tchains.reshape(statevars.ndim,statevars.tchains.shape[1]*statevars.tchains.shape[2]).transpose(),

--- a/radvel/model.py
+++ b/radvel/model.py
@@ -13,6 +13,8 @@ texdict = {
     'tc': 'T\\rm{conj}',
     'secosw': '\\sqrt{e}\\cos{\\omega}',
     'sesinw': '\\sqrt{e}\\sin{\\omega}',
+    'ecosw': 'e\\cos{\\omega}',
+    'esinw': 'e\\sin{\\omega}',
     'e': 'e',
     'w': '\\omega',
     'tp': 'T\\rm{peri}',

--- a/radvel/model.py
+++ b/radvel/model.py
@@ -1,6 +1,7 @@
 import numpy as np
 import copy_reg
 import types
+from collections import OrderedDict
 
 from . import kepler
 from .basis import Basis
@@ -22,7 +23,7 @@ texdict = {
     'curv': '\\ddot{\\gamma}'
 }
 
-class RVParameters(dict):
+class RVParameters(OrderedDict):
     """Object to store the orbital parameters.
 
     Args:
@@ -47,18 +48,24 @@ class RVParameters(dict):
        >>> params = radvel.RVParameters(2, planet_letters={1:'d', 2:'e'})
 
     """
-    def __init__(self, num_planets, basis='per tc secosw sesinw logk', 
-                 planet_letters=None):
-        self.basis = Basis(basis,num_planets)
+    # def __init__(self, num_planets, basis='per tc secosw sesinw logk', 
+    #              planet_letters=None):
+    def __init__(self, *args, **kwargs):
+        self.num_planets = args[0]
+        basis = kwargs.pop('basis', 'per tc secosw sesinw logk')
+        planet_letters = kwargs.pop('planet_letters', None)
+        super(RVParameters, self).__init__(**kwargs)
+        self.basis = Basis(basis,self.num_planets)
         self.planet_parameters = basis.split()
-        for num_planet in range(1,1+num_planets):
+        for num_planet in range(1,1+self.num_planets):
             for parameter in self.planet_parameters:
                 self.__setitem__(self._sparameter(parameter, num_planet), None)
-                
-        self.num_planets = num_planets
+
         if planet_letters is not None:
             for k in planet_letters.keys():
-                assert isinstance(k, int), "RVParameters: ERROR: The planet_letters dictionary should have only integers as keys."
+                assert isinstance(k, int), """\
+RVParameters: ERROR: The planet_letters dictionary \
+should have only integers as keys."""
 
         self.planet_letters = planet_letters
 
@@ -103,6 +110,18 @@ class RVParameters(dict):
             lett_planet = chr(int(num_planet)+97)
         return '$%s_{%s}$' % (pname, lett_planet) 
 
+    def copy(self, new_basis=None):
+        if new_basis is None:
+            new_basis = self.basis.name
+
+        params_out = RVParameters(
+            self.num_planets, basis=new_basis,
+            planet_letters=self.planet_letters)
+    
+        params_out.update(self)
+        
+        return params_out
+    
 class RVModel(object):
     """
     Generic RV Model
@@ -151,6 +170,14 @@ class RVModel(object):
         vel+=self.params['dvdt'] * ( t - self.time_base )
         vel+=self.params['curv'] * ( t - self.time_base )**2
         return vel
+
+    def copy(self):
+        params = self.params.copy()
+        time_base = self.time_base
+
+        new = RVModel(params, time_base=time_base)
+
+        return new
 
 # I had to add these methods to get the model object to be
 # pickle-able, so we could run the mcmc in as a in multi-threaded

--- a/radvel/plotting.py
+++ b/radvel/plotting.py
@@ -143,7 +143,7 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
     bin_fac = 1.75
     bin_markersize = bin_fac * rcParams['lines.markersize']
     bin_markeredgewidth = bin_fac * rcParams['lines.markeredgewidth']
-    fit_linewidth = 3.0
+    fit_linewidth = 2.0
 
     cpspost = copy.deepcopy(post) 
     model = cpspost.likelihood.model
@@ -250,7 +250,7 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
    
     #Unphased plot
     ax.axhline(0, color='0.5', linestyle='--')
-    ax.plot(mplttimes,rvmod2,'b-', rasterized=False, lw=0.5*fit_linewidth)
+    ax.plot(mplttimes,rvmod2,'b-', rasterized=False, lw=0.1)
 
     def labelfig(ax, pltletter):
         text = "{})".format(chr(pltletter))
@@ -444,7 +444,7 @@ def corner_plot(post, chains, saveplot=None):
     
     fig = corner.corner(
         chains[labels], labels=texlabels, label_kwargs={"fontsize": 14},
-        plot_datapoints=False, bins=20, quantiles=[.16,.5,.84],
+        plot_datapoints=False, bins=30, quantiles=[.16,.5,.84],
         show_titles = True, title_kwargs={"fontsize": 14}, smooth=True
     )
     
@@ -501,7 +501,7 @@ def corner_plot_derived_pars(chains, P, saveplot=None):
     rcParams['font.size'] = 12
     fig = corner.corner(
         chains[labels], labels=texlabels, label_kwargs={"fontsize": 14}, 
-        plot_datapoints=False, bins=20, quantiles=[0.16,0.50,0.84],
+        plot_datapoints=False, bins=30, quantiles=[0.16,0.50,0.84],
         show_titles = True, title_kwargs={"fontsize": 14}, smooth=True
     )
     

--- a/radvel/plotting.py
+++ b/radvel/plotting.py
@@ -114,7 +114,7 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
         yscale_auto (bool, optional): Use matplotlib auto y-axis
              scaling (default: False)
         yscale_sigma (float, optional): Scale y-axis limits to be +/-
-             yscale_sigma*(RMS of data plotted)
+             yscale_sigma*(RMS of data plotted) if yscale_auto==False
         telfmts (dict, optional): dictionary of dictionaries mapping
              instrument code to plotting format code.
         nophase (bool, optional): Will omit phase-folded plots if true
@@ -313,6 +313,7 @@ def rv_multipanel_plot(post, saveplot=None, telfmts={}, nobin=False,
         ax.set_ylim(-yscale_sigma * scale, yscale_sigma * scale)
 
     ax.set_xlim(min(plttimes)-0.01*dt,max(plttimes)+0.01*dt)
+    ticks = ax.yaxis.get_majorticklocs()
     ax.yaxis.set_ticks([ticks[0],0.0,ticks[-1]])
     xticks = ax.xaxis.get_majorticklocs()
     pl.xlabel('JD - {:d}'.format(int(np.round(e))), weight='bold')

--- a/radvel/posterior.py
+++ b/radvel/posterior.py
@@ -20,7 +20,7 @@ class Posterior(Likelihood):
         to apply priors in the likelihood calculations.
     """
     
-    def __init__(self,likelihood, setup=None):
+    def __init__(self,likelihood):
         self.likelihood = likelihood
         self.params = likelihood.params
         self.vary = likelihood.vary
@@ -35,6 +35,17 @@ class Posterior(Likelihood):
             s +=  prior.__repr__() + "\n"
         return s
 
+    def copy(self):
+        like = self.likelihood.copy()
+
+        new = Posterior(like)
+        new.params = self.params.copy()
+        new.vary = self.vary
+        new.uparams = self.uparams
+        new.priors = self.priors
+        
+        return new
+    
     def logprob(self):
         """Log probability
 

--- a/radvel/posterior.py
+++ b/radvel/posterior.py
@@ -34,17 +34,6 @@ class Posterior(Likelihood):
         for prior in self.priors:
             s +=  prior.__repr__() + "\n"
         return s
-
-    def copy(self):
-        like = self.likelihood.copy()
-
-        new = Posterior(like)
-        new.params = self.params.copy()
-        new.vary = self.vary
-        new.uparams = self.uparams
-        new.priors = self.priors
-        
-        return new
     
     def logprob(self):
         """Log probability
@@ -113,4 +102,8 @@ def load(filename):
     with open(filename, 'rb') as f:
         post = pickle.load(f)
 
+    for key,val in post.params.items():
+        if val is None:
+            del post.params[key]
+    
     return post

--- a/radvel/prior.py
+++ b/radvel/prior.py
@@ -91,15 +91,22 @@ upper limits must match number of planets."
     def __call__(self, params):
         def _getpar(key, num_planet):
             return params['{}{}'.format(key,num_planet)]
+
+        parnames = params.basis.name.split()
         
         for i,num_planet in enumerate(self.planet_list):
-            try:
+            if 'e' in parnames:
                 ecc = _getpar('e', num_planet)
-            except KeyError:
+            elif 'secosw' in parnames:
                 secosw = _getpar('secosw',num_planet)
                 sesinw = _getpar('sesinw',num_planet)
                 ecc = secosw**2 + sesinw**2 
+            elif 'ecosw' in parnames:
+                ecosw = _getpar('ecosw',num_planet)
+                esinw = _getpar('esinw',num_planet)
+                ecc = np.sqrt(ecosw**2 + esinw**2)
 
+                
             if ecc > self.upperlims[i] or ecc < 0.0:
                 return -np.inf
         

--- a/radvel/report.py
+++ b/radvel/report.py
@@ -75,10 +75,9 @@ class RadvelReport():
 
     def _postamble(self):
         return """
-\\lfoot{{\\footnotesize{{report produced by \\texttt{{RadVel}} v{}, \
-documentation available at \\href{{http://radvel.readthedocs.io}}{{http://radvel.readthedocs.io}}}}}}
+\\lfoot{{\\footnotesize{{report produced by \\texttt{{RadVel}} v{}: \
+\\href{{http://radvel.readthedocs.io}}{{http://radvel.readthedocs.io}}}}}}
 \\end{{document}}""".format(radvel.__version__)
-    
 
     def texdoc(self):
         """TeX for entire document

--- a/radvel/report.py
+++ b/radvel/report.py
@@ -31,9 +31,11 @@ class RadvelReport():
     Class to handle the creation of the radvel summary PDF
 
     Args:
-        planet (planet object): planet configuration object loaded in `kepfit.py` using `imp.load_source`
-        post (radvel.posterior): radvel.posterior object containing the best-fit parameters in post.params
-        chains (DataFrame): output DataFrame from a `radvel.mcmc` run
+        planet (planet object): planet configuration object loaded in 
+        `kepfit.py` using `imp.load_source` post (radvel.posterior): 
+        radvel.posterior object containing the best-fit parameters in 
+        post.params chains (DataFrame): output DataFrame from a 
+        `radvel.mcmc` run
     """
     
     def __init__(self, planet, post, chains, compstats=None):
@@ -46,17 +48,20 @@ class RadvelReport():
                 
         printpost = copy.deepcopy(post)
         printpost.params = printpost.params.basis.to_cps(printpost.params)
-        printpost.params = printpost.params.basis.from_cps(printpost.params, print_basis)
+        printpost.params = printpost.params.basis.from_cps(printpost.params,
+                                                               print_basis)
         self.latex_dict = printpost.params.tex_labels()
 
-        printchains = copy.deepcopy(chains)
+        printchains = copy.copy(chains)
         for p in post.params.keys():
             if p not in chains.columns:
                 chains[p] = post.params[p]
-        self.chains = printpost.params.basis.to_cps(chains)
-        self.chains = printpost.params.basis.from_cps(chains, print_basis)
-        self.quantiles = chains.quantile([0.159, 0.5, 0.841])
-
+        self.chains = printpost.params.basis.to_cps(chains,
+                                            basis_name=planet.fitting_basis)
+        self.chains = printpost.params.basis.from_cps(self.chains, print_basis)
+        self.quantiles = self.chains.quantile([0.159, 0.5, 0.841])
+        print(self.quantiles)
+        
         self.compstats = compstats
         
     def _preamble(self):

--- a/radvel/report.py
+++ b/radvel/report.py
@@ -60,21 +60,24 @@ class RadvelReport():
                                             basis_name=planet.fitting_basis)
         self.chains = printpost.params.basis.from_cps(self.chains, print_basis)
         self.quantiles = self.chains.quantile([0.159, 0.5, 0.841])
-        print(self.quantiles)
         
         self.compstats = compstats
         
     def _preamble(self):
         return """
-\\documentclass{emulateapj}
-\\usepackage{graphicx,textcomp}
-\\begin{document}
-\\shorttitle{Summary of \\texttt{RADVEL} results for %s}
-""" % (self.starname_tex)
+\\documentclass{{emulateapj}}
+\\usepackage{{graphicx,textcomp,fancyhdr,hyperref}}
+\\begin{{document}}
+\\pagestyle{{fancy}}
+\\pagenumbering{{gobble}}
+\\chead{{Summary of \\texttt{{RadVel}} results for {}}}
+""".format(self.starname_tex)
 
     def _postamble(self):
         return """
-\\end{document}"""
+\\lfoot{{\\footnotesize{{report produced by \\texttt{{RadVel}} v{}, \
+documentation available at \\href{{http://radvel.readthedocs.io}}{{http://radvel.readthedocs.io}}}}}}
+\\end{{document}}""".format(radvel.__version__)
     
 
     def texdoc(self):
@@ -88,11 +91,14 @@ class RadvelReport():
         
         out = self._preamble() + self.tabletex()
         if os.path.exists(self.runname+"_rv_multipanel.pdf"):
-            out += self.figtex(self.runname+"_rv_multipanel.pdf", caption=self._bestfit_caption())
+            out += self.figtex(self.runname+"_rv_multipanel.pdf",
+                                   caption=self._bestfit_caption())
         if os.path.exists(self.runname+"_corner.pdf"):
-            out += self.figtex(self.runname+"_corner.pdf", caption="Posterior distributions for all free parameters.")
+            out += self.figtex(self.runname+"_corner.pdf",
+                caption="Posterior distributions for all free parameters.")
         if os.path.exists(self.runname+"_corner_derived_pars.pdf"):
-            out += self.figtex(self.runname+"_corner_derived_pars.pdf", caption="Posterior distributions for all derived parameters.")
+            out += self.figtex(self.runname+"_corner_derived_pars.pdf",
+                caption="Posterior distributions for all derived parameters.")
 
         out += self._postamble()
         

--- a/radvel/utils.py
+++ b/radvel/utils.py
@@ -16,7 +16,8 @@ def initialize_posterior(config_file, decorr=False):
     system_name = P.starname
 
     cpsparams = P.params.basis.to_cps(P.params)
-    params = P.params.basis.from_cps(cpsparams, P.fitting_basis, keep=False)
+    params = P.params.basis.from_cps(cpsparams,
+                                            P.fitting_basis, keep=False)
 
     if decorr:
         try:
@@ -41,14 +42,15 @@ Converting 'logjit' to 'jit' for you now.
             del P.vary[key]
             del params[key]
 
-    iparams = params.copy()
-
+    #iparams = params.copy()
+    iparams = radvel.basis._copy_params(params)
+    
     # Make sure we don't have duplicate indicies in the DataFrame
     P.data = P.data.reset_index(drop=True)
     
     # initialize RVmodel object
     mod = radvel.RVModel(params, time_base=P.time_base)   
-
+    
     # initialize RVlikelihood objects for each instrument
     telgrps = P.data.groupby('tel').groups
     likes = {}
@@ -74,6 +76,7 @@ Converting 'logjit' to 'jit' for you now.
     # Initialize Posterior object
     post = radvel.posterior.Posterior(like)
     post.priors = P.priors
+    
     return P, post
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ corner>=2.0
 cython>=0.22
 astropy>=1.1.2
 emcee>=2.2.1
+pp==1.6.5


### PR DESCRIPTION
I changed the real time MCMC convergence tests to address the statistical issues raised in issue #60. I now run several ensembles in parallel on separate CPUs (8 by default) and calculate G-R and Tz across these ensembles instead of within a single ensemble. Convergence speed seems to be pretty similar, but many more steps are calculated per unit time thanks to the multi-threading.

The `RVParameters` object is now an OrderedDict. This was causing big problems with the multi-threading thanks to the unordered nature of Python dictionaries. The parameter order returned by `likelihood.get_vary_params()` and `likelihood.list_vary_params()` was changing as the likelihood objects were pickled and sent to different cores. I believe that this may have been related to the multi-threading issues mentioned in issue #8, but multi-threading within a single ensemble is still broken for apparently a different reason.

I implemented a `per ecosw esinw k` basis.

Experimental decorrelation (linear) of the RVs w/ parameters stored in the input DataFrame containing the RV data is implemented, but not well-tested or documented.