### PR TITLE
fix to BIC formula

### DIFF
--- a/radvel/posterior.py
+++ b/radvel/posterior.py
@@ -59,8 +59,10 @@ class Posterior(Likelihood):
             float: BIC
         """
         
-        return -2.0 * self.logprob() + len(self.likelihood.get_vary_params()) + np.log(len(self.likelihood.y))
-
+        n = len(self.likelihood.y)
+        k = len(self.likelihood.get_vary_params())
+        _bic = np.log(n) * k - 2.0 * self.logprob() 
+        return _bic
     
     def logprob_array(self, params_array):
         """Log probability for parameter vector


### PR DESCRIPTION
Hey @bjfultn, @madisontbrady pointed out an an error in how the BIC was calculated. Previously, it was computed as

-2.0 * log(L)  + k  + log(n)

n is the number of data points
k is the number of free parameters
L is the likelihood.

The patch changes it to:

log(n) * k - 2 * log (L)

which is consistent with [wikipedia](https://en.wikipedia.org/wiki/Bayesian_information_criterion)
