### PR TITLE
Fixing bug with deepcopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
      - $HOME/download
      - $HOME/miniconda2
      - $HOME/miniconda3
+     - $HOME/.cache/pip
+     - $HOME/.ccache
 
 python:
   - "2.7"
@@ -22,9 +24,10 @@ before_install:
     - sudo ln -s /run/shm /dev/shm
 
 install:
-    - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy matplotlib cython pandas
-    - pip install nose coveralls nbformat nbconvert jupyter_client ipykernel
-    - pip install . --upgrade
+    - conda install --yes pip numpy scipy matplotlib cython pandas nose nbformat nbconvert jupyter_client ipykernel
+    - if [ ${py} == "2" ]; then conda install --yes configparser==3.5.0b2; fi
+    - pip install coveralls
+    - pip install .
     - python setup.py build_ext -i
 
 # configure a headless display using xvbf to test plot generation
@@ -33,7 +36,6 @@ before_script:
     - "sh -e /etc/init.d/xvfb start"
     - sleep 2 # give xvfb some time to start
 
-# run tests in Travis-CI virtual env
 script:
     - nosetests radvel --with-coverage --cover-package=radvel
 

--- a/radvel/mcmc.py
+++ b/radvel/mcmc.py
@@ -242,7 +242,7 @@ of free parameters. Adjusting number of walkers to {}".format(2*statevars.ndim))
         
     df = pd.DataFrame(
         statevars.tchains.reshape(statevars.ndim,statevars.tchains.shape[1]*statevars.tchains.shape[2]).transpose(),
-        columns=post.list_vary_params())
+        columns=pcopy.list_vary_params())
     df['lnprobability'] = np.hstack(statevars.lnprob)
 
     df = df.iloc[::thin]


### PR DESCRIPTION
Creating a `deepcopy` of a `Posterior` object sometimes jumbles the order of parameters (in Python 2.7, at least). This can lead to all sorts of nastiness, but is easily fixed by defining the `pandas` `DataFrame` returned at the end of `mcmc` using the copied `Posterior` object, not the original one.