### PR TITLE
Added printout of final reduced chi-square

### DIFF
--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -190,6 +190,9 @@ def mcmc(args):
 
     final_logprob = post.logprob()
     final_residuals = post.likelihood.residuals().std()
+    final_chisq = np.sum(post.likelihood.residuals()**2 / (post.likelihood.errorbars()**2) )
+    deg_of_freedom = len(post.likelihood.y) - len(post.likelihood.get_vary_params())
+    final_chisq_reduced = final_chisq / deg_of_freedom
     synthparams = post.params.basis.to_synth(post.params)
     post.params.update(synthparams)
 
@@ -218,6 +221,7 @@ def mcmc(args):
 
     print("Final loglikelihood = %f" % final_logprob)
     print("Final RMS = %f" % final_residuals)
+    print("Final reduced chi-square = {}".format(final_chisq_reduced))
     print("Best-fit parameters:")
     print(post)
 


### PR DESCRIPTION
I added a line of code that prints the final reduced chisq value after post-MCMC max likelihood fit (along with RMS, loglikelihood, etc(. I found this feature useful. @bjfultn if you don't think it's a necessary thing to include in radvel feel free not to merge this branch.