### PR TITLE
Version 1.2.2

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,10 @@ modeling of radial velocity time series data.
 
 Please cite `Fulton, Petigura, Blunt & Sinukoff (2018)  <http://adsabs.harvard.edu/abs/2018PASP..130d4504F>`_ and the following DOI if you make use of RadVel in your research.
 
+Bug reports and feature requests should be posted to the `GitHub issue tracker <https://github.com/California-Planet-Search/radvel/issues>`_ .
+
+Code contributions are welcome and should be submitted as a pull request. Read `the paper <http://adsabs.harvard.edu/abs/2018PASP..130d4504F>`_ for further details regarding contributions.
+
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.580821.svg
    :target: https://doi.org/10.5281/zenodo.580821
 

--- a/radvel/__init__.py
+++ b/radvel/__init__.py
@@ -19,7 +19,7 @@ def _custom_warningfmt(msg, *a, **b):
 __all__=['model', 'likelihood', 'posterior', 'mcmc', 'prior', 'utils',
          'fitting', 'report', 'cli', 'driver', 'gp']
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 MODULEDIR, filename = os.path.split(__file__)
 DATADIR = os.path.join(sys.prefix, 'radvel_example_data')

--- a/radvel/likelihood.py
+++ b/radvel/likelihood.py
@@ -311,7 +311,7 @@ class RVLikelihood(Likelihood):
         Returns:
             float: Natural log of likelihood
         """
-        
+
         sigma_jit = self.params[self.jit_param].value
         residuals = self.residuals()
         loglike = loglike_jitter(residuals, self.yerr, sigma_jit)
@@ -511,7 +511,7 @@ class CeleriteLikelihood(GPLikelihood):
             solver = self.kernel.compute_covmatrix(self.errorbars())
 
             # calculate log likelihood
-            lnlike =  -0.5 * (solver.dot_solve(self._resids()) + solver.log_determinant() + self.N*np.log(2.*np.pi))
+            lnlike = -0.5 * (solver.dot_solve(self._resids()) + solver.log_determinant() + self.N*np.log(2.*np.pi))
         
             return lnlike
 

--- a/radvel/posterior.py
+++ b/radvel/posterior.py
@@ -85,6 +85,17 @@ class Posterior(Likelihood):
 
         return self.likelihood.residuals()
 
+    def bic(self):
+        """Moved to Likelihood.bic"""
+
+        return self.likelihood.bic()
+
+    def aic(self):
+        """Moved to Likelihood.aic"""
+
+        raise self.likelihood.aic()
+
+
 def load(filename):
     """
     Load posterior object from pickle file.


### PR DESCRIPTION
- added dummy functions for `bic` and `aic` back into the posterior object which redirect to `self.likelihood.bic/aic` for backwards compatibility
- added to the docs

