### PR TITLE
remove trailing whitespace everywhere

### DIFF
--- a/example_planets/epic203771098.py
+++ b/example_planets/epic203771098.py
@@ -73,7 +73,7 @@ priors = [
 ]
 
 # abscissa for slope and curvature terms (should be near mid-point of time baseline)
-time_base = np.mean([np.min(data.time), np.max(data.time)])  
+time_base = np.mean([np.min(data.time), np.max(data.time)])
 
 
 # optional argument that can contain stellar mass in solar units (mstar) and

--- a/example_planets/k2-131.py
+++ b/example_planets/k2-131.py
@@ -14,15 +14,15 @@ before coming back to this configuration file.
 # Data from Dai et al. (2017)
 instnames = ['harps-n','pfs']  # no spaces in instrument names
 data = pd.read_csv(os.path.join(radvel.DATADIR,'k2-131.txt'), sep=' ')
-t = np.array(data['time']) 
+t = np.array(data['time'])
 vel = np.array(data['mnvel'])
 errvel = np.array(data['errvel'])
 telgrps = data.groupby('tel').groups
-bjd = 0. 
+bjd = 0.
 
 starname = 'k2-131'
-ntels = len(instnames)      
-planet_letters = {1: 'b'}   
+ntels = len(instnames)
+planet_letters = {1: 'b'}
 
 nplanets = 1
 fitting_basis = 'per tc secosw sesinw k'
@@ -32,7 +32,7 @@ gp_explength_mean = 9.5*np.sqrt(2.) # sqrt(2)*tau in Dai et al. (2017) [days]
 gp_explength_unc = 1.0*np.sqrt(2.)
 gp_perlength_mean = np.sqrt(1./(2*3.32)) # sqrt(1/2*gamma) in Dai et al. (2017)
 gp_perlength_unc = 0.04
-""" 
+"""
 NOTE: this prior isn't equivalent to the one Dai et al. (2017) use. However,
 our formulation of the quasi-periodic kernel explicitly keeps the covariance
 matrix postitive semi-definite, so we use this instead. The orbit model
@@ -42,7 +42,7 @@ results aren't affected.
 gp_per_mean = 9.64 # T_bar in Dai et al. (2017) [days]
 gp_per_unc = 0.12
 Porb = 0.3693038 # [days]
-Porb_unc = 0.0000091 
+Porb_unc = 0.0000091
 Tc = 2457582.9360 # [BJD]
 Tc_unc = 0.0011
 
@@ -61,8 +61,8 @@ time_base = np.median(t)
 # Define GP hyperparameters as Parameter objects.
 params['gp_amp_j'] = radvel.Parameter(value=26.0)
 params['gp_amp_h'] = radvel.Parameter(value=26.0)
-params['gp_explength'] = radvel.Parameter(value=gp_explength_mean) 
-params['gp_per'] = radvel.Parameter(value=gp_per_mean) 
+params['gp_explength'] = radvel.Parameter(value=gp_explength_mean)
+params['gp_per'] = radvel.Parameter(value=gp_per_mean)
 params['gp_perlength'] = radvel.Parameter(value=gp_perlength_mean)
 
 
@@ -77,13 +77,13 @@ hnames = {
               'gp_per', # GP variability period
               'gp_explength', # GP non-periodic characteristic length
               'gp_perlength'], # GP periodic characteristic length
-  'pfs': ['gp_amp_j', 
-          'gp_per', 
-          'gp_explength', 
+  'pfs': ['gp_amp_j',
+          'gp_per',
+          'gp_explength',
           'gp_perlength']
 }
 
-kernel_name = {'harps-n':"QuasiPer", 
+kernel_name = {'harps-n':"QuasiPer",
                'pfs':"QuasiPer"}
 """
 NOTE: If all kernels are quasi-periodic, you don't need to include the
@@ -98,7 +98,7 @@ def initialize_instparams(tel_suffix):
     indices = telgrps[tel_suffix]
 
     params['gamma_'+tel_suffix] = radvel.Parameter(value=np.mean(vel[indices]))
-    params['jit_'+tel_suffix] = radvel.Parameter(value=jit_guesses[tel_suffix]) 
+    params['jit_'+tel_suffix] = radvel.Parameter(value=jit_guesses[tel_suffix])
 
 
 for tel in instnames:

--- a/example_planets/k2-131_celerite.py
+++ b/example_planets/k2-131_celerite.py
@@ -9,21 +9,21 @@ import radvel
 # Data from Dai+ 2017
 instnames = ['harps-n', 'pfs']  # no spaces in instrument names
 data = pd.read_csv(os.path.join(radvel.DATADIR, 'k2-131.txt'), sep=' ')
-t = np.array(data['time']) 
+t = np.array(data['time'])
 vel = np.array(data['mnvel'])
 errvel = np.array(data['errvel'])
 telgrps = data.groupby('tel').groups
-bjd = 0. 
+bjd = 0.
 
 # Constraints from transits
 Porb = 0.3693038  # [days]
-Porb_unc = 0.0000091 
+Porb_unc = 0.0000091
 Tc = 2457582.9360  # [BJD]
 Tc_unc = 0.0011
 
 starname = 'k2-131'
-ntels = len(instnames)      
-planet_letters = {1: 'b'}   
+ntels = len(instnames)
+planet_letters = {1: 'b'}
 
 nplanets = 1
 fitting_basis = 'per tc secosw sesinw k'
@@ -44,7 +44,7 @@ time_base = np.median(t)
 
 # Define Celerite GP hyperparameters.
 params['gp_B'] = radvel.Parameter(value=30**2., vary=True)
-params['gp_C'] = radvel.Parameter(value=1., vary=True) 
+params['gp_C'] = radvel.Parameter(value=1., vary=True)
 params['gp_L'] = radvel.Parameter(value=9., vary=True)
 params['gp_Prot'] = radvel.Parameter(value=9., vary=True)
 

--- a/radvel/basis.py
+++ b/radvel/basis.py
@@ -50,7 +50,7 @@ def _copy_params(params_in):
     params_out = radvel.model.Parameters(num_planets, basis=basis,
                                          planet_letters=planet_letters)
     params_out.update(params_in)
-    
+
     return params_out
 
 
@@ -69,7 +69,7 @@ class Basis(object):
     Note:
         Valid basis functions: \n
         'per tp e w k' (The synthesis basis) \n
-        'per tc secosw sesinw logk'  \n 
+        'per tc secosw sesinw logk'  \n
         'per tc secosw sesinw k'  \n
         'per tc ecosw esinw k'  \n
         'per tc e w k' \n
@@ -85,7 +85,7 @@ class Basis(object):
         if len(args) == 0:
             _print_valid_basis()
         #    return None
-        
+
         name, num_planets = args
 
         if BASIS_NAMES.count(name) == 0:
@@ -121,12 +121,12 @@ class Basis(object):
         synth basis
 
         Args:
-            params_in (radvel.Parameters or pandas.DataFrame):  radvel.Parameters object or pandas.Dataframe containing 
+            params_in (radvel.Parameters or pandas.DataFrame):  radvel.Parameters object or pandas.Dataframe containing
                 orbital parameters expressed in current basis
-            noVary (bool [optional]): if True, set the 'vary' attribute of the returned Parameter objects 
+            noVary (bool [optional]): if True, set the 'vary' attribute of the returned Parameter objects
                 to '' (used for displaying best fit parameters)
 
-        Returns: 
+        Returns:
             Parameters or DataFrame: parameters expressed in the synth basis
 
         """
@@ -162,7 +162,7 @@ class Basis(object):
                         local_vary = True
                         local_mcmcscale = None
 
-                    params_out[key_name] = radvel.model.Parameter(value=new_value, 
+                    params_out[key_name] = radvel.model.Parameter(value=new_value,
                                                                   vary=local_vary,
                                                                   mcmcscale=local_mcmcscale)
 
@@ -172,9 +172,9 @@ class Basis(object):
                 per = _getpar('per')
                 tp = _getpar('tp')
                 e = _getpar('e')
-                w = _getpar('w')   
+                w = _getpar('w')
                 k = _getpar('k')
-                
+
             if basis_name == 'per tc e w k':
                 per = _getpar('per')
                 tc = _getpar('tc')
@@ -192,7 +192,7 @@ class Basis(object):
                 k = _getpar('k')
                 e = se**2
                 tp = timetrans_to_timeperi(tc, per, e, w)
-    
+
             if basis_name == 'per tc secosw sesinw logk':
                 # pull out parameters
                 per = _getpar('per')
@@ -213,7 +213,7 @@ class Basis(object):
                 secosw = _getpar('secosw')
                 sesinw = _getpar('sesinw')
                 k = _getpar('k')
-            
+
                 # transform into synth basis
                 e = secosw**2 + sesinw**2
                 w = np.arctan2(sesinw, secosw)
@@ -226,7 +226,7 @@ class Basis(object):
                 secosw = _getpar('secosw')
                 sesinw = _getpar('sesinw')
                 k = _getpar('k')
-            
+
                 # transform into synth basis
                 per = np.exp(logper)
                 e = secosw**2 + sesinw**2
@@ -255,7 +255,7 @@ class Basis(object):
                 ecosw = _getpar('ecosw')
                 esinw = _getpar('esinw')
                 k = _getpar('k')
-            
+
                 # transform into synth basis
                 e = np.sqrt(ecosw**2 + esinw**2)
                 w = np.arctan2(esinw, ecosw)
@@ -272,7 +272,7 @@ class Basis(object):
                 # transform into synth basis
                 per = np.exp(logper)
                 k = np.exp(k)
-                
+
             # shoves synth parameters from namespace into param_out
             _setpar('per', per)
             _setpar('tp', tp)
@@ -290,7 +290,7 @@ class Basis(object):
         Convert instance of Parameters with parameters of a given basis into the synth basis
 
         Args:
-            params_in (radvel.Parameters or pandas.DataFrame):  radvel.Parameters object or pandas.Dataframe containing 
+            params_in (radvel.Parameters or pandas.DataFrame):  radvel.Parameters object or pandas.Dataframe containing
                 orbital parameters expressed in current basis
             newbasis (string): string corresponding to basis to switch into
             keep (bool [optional]): keep the parameters expressed in
@@ -300,12 +300,12 @@ class Basis(object):
         Returns:
             dict or dataframe with the parameters converted into the new basis
         """
-        
+
         if newbasis not in BASIS_NAMES:
             print("{} not valid basis".format(newbasis))
             _print_valid_basis()
             return None
-        
+
         if isinstance(params_in, pd.core.frame.DataFrame):
             # Output by emcee
             params_out = params_in.copy()
@@ -333,8 +333,8 @@ class Basis(object):
                         local_vary = True
                         local_mcmcscale = None
 
-                    params_out[key_name] = radvel.model.Parameter(value=new_value, 
-                                                                  vary=local_vary, 
+                    params_out[key_name] = radvel.model.Parameter(value=new_value,
+                                                                  vary=local_vary,
                                                                   mcmcscale=local_mcmcscale)
 
             def _delpar(key):
@@ -348,7 +348,7 @@ class Basis(object):
                 e = _getpar('e')
                 w = _getpar('w')
                 tp = _getpar('tp')
-                
+
                 _setpar('tc', timeperi_to_timetrans(tp, per, e, w))
                 _setpar('w', w)
 
@@ -360,7 +360,7 @@ class Basis(object):
                 e = _getpar('e')
                 w = _getpar('w')
                 tp = _getpar('tp')
-                
+
                 _setpar('tc', timeperi_to_timetrans(tp, per, e, w))
                 _setpar('w', w)
                 _setpar('se', np.sqrt(e))
@@ -380,7 +380,7 @@ class Basis(object):
                     tc = _getpar('tc')
                     tp = timetrans_to_timeperi(tc, per, e, w)
                     _setpar('tp', tp)
-                    
+
                 _setpar('secosw', np.sqrt(e)*np.cos(w))
                 _setpar('sesinw', np.sqrt(e)*np.sin(w))
                 _setpar('logk', np.log(k))
@@ -394,7 +394,7 @@ class Basis(object):
 
                 # basis_name = newbasis
                 self.params = newbasis.split()
-                
+
             if newbasis == 'per tc secosw sesinw k':
                 per = _getpar('per')
                 e = _getpar('e')
@@ -518,16 +518,16 @@ class Basis(object):
 
                 self.name = newbasis
                 self.params = newbasis.split()
-                
+
         params_out.basis = Basis(newbasis, self.num_planets)
-                
+
         return params_out
 
     def get_eparams(self):
         """Return the eccentricity parameters for the object's basis
 
         Returns:
-            the params which have to do with eccentricity 
+            the params which have to do with eccentricity
         """
 
         assert BASIS_NAMES.count(self.name) == 1, "Invalid basis"
@@ -535,19 +535,19 @@ class Basis(object):
         eparamstring = ECCENTRICITY_PARAMS_DICT[self.name]
         eparamlist = eparamstring.split()
         assert len(eparamlist) == 2
-    
-        return eparamlist 
+
+        return eparamlist
 
     def get_circparams(self):
         """Return the 3 parameters for a circular orbit of a plent in the object's basis
 
         Returns:
-            the params for a circular orbit 
+            the params for a circular orbit
         """
         assert BASIS_NAMES.count(self.name) == 1, "Invalid basis"
 
         circparamstring = CIRCULAR_PARAMS_DICT[self.name]
         circparamlist = circparamstring.split()
         assert len(circparamlist) == 3
-    
+
         return circparamlist

--- a/radvel/cli.py
+++ b/radvel/cli.py
@@ -52,7 +52,7 @@ def main():
                           help="type of plot(s) to generate"
                           )
     psr_plot.add_argument('--plotkw', dest='plotkw', action='store', default="{}", type=eval,
-                          help='''Dictionary of keywords sent to MultipanelPlot or GPMultipanelPlot. 
+                          help='''Dictionary of keywords sent to MultipanelPlot or GPMultipanelPlot.
 E.g. --plotkw "{'yscale_auto': True}"' ''')
     psr_plot.add_argument('--gp',
                           dest='gp',
@@ -60,7 +60,7 @@ E.g. --plotkw "{'yscale_auto': True}"' ''')
                           default=False,
                           help="Make a multipanel plot with GP bands. For use only with GPLikleihood objects"
                           )
-    
+
     psr_plot.set_defaults(func=radvel.driver.plots)
 
     # MCMC
@@ -107,7 +107,7 @@ Convergence checks will start after the minsteps threshold or the minpercent thr
                                      )
 
     psr_physical.set_defaults(func=radvel.driver.derive)
-    
+
     # Information Criteria comparison (BIC/AIC)
     psr_ic = subpsr.add_parser('ic', parents=[psr_parent],)
     psr_ic.add_argument('-t', '--type', type=str, nargs='+', default='trend',
@@ -147,7 +147,7 @@ Convergence checks will start after the minsteps threshold or the minpercent thr
                            help='''Include star name in table headers. Default just prints \
 descriptive titles without star name [False]'''
                            )
-    
+
     psr_table.set_defaults(func=radvel.driver.tables)
 
     # Report
@@ -160,7 +160,7 @@ descriptive titles without star name [False]'''
     psr_report.add_argument('--latex-compiler', default='pdflatex', type=str, help='Path to latex compiler')
 
     psr_report.set_defaults(func=radvel.driver.report)
-    
+
     args = psr.parse_args()
 
     if args.outputdir is None:
@@ -169,10 +169,10 @@ descriptive titles without star name [False]'''
         system_name = os.path.basename(setupfile).split('.')[0]
         outdir = os.path.join('./', system_name)
         args.outputdir = outdir
-            
+
     if not os.path.isdir(args.outputdir):
         os.mkdir(args.outputdir)
-        
+
     args.func(args)
 
 

--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -32,7 +32,7 @@ def plots(args):
     Args:
         args (ArgumentParser): command line arguments
     """
-    
+
     config_file = args.setupfn
     conf_base = os.path.basename(config_file).split('.')[0]
     statfile = os.path.join(
@@ -112,8 +112,8 @@ You may want to use the '--gp' flag when making these plots.")
 
         savestate = {'{}_plot'.format(ptype): os.path.relpath(saveto)}
         save_status(statfile, 'plot', savestate)
-            
-        
+
+
 def fit(args):
     """Perform maximum a posteriori fit
 
@@ -128,11 +128,11 @@ def fit(args):
     P, post = radvel.utils.initialize_posterior(config_file, decorr=args.decorr)
 
     post = radvel.fitting.maxlike_fitting(post, verbose=True)
-    
+
     postfile = os.path.join(args.outputdir,
                             '{}_post_obj.pkl'.format(conf_base))
     post.writeto(postfile)
-    
+
     savestate = {'run': True,
                  'postfile': os.path.relpath(postfile)}
     save_status(os.path.join(args.outputdir,
@@ -183,7 +183,7 @@ def mcmc(args):
     synthchains = post.params.basis.to_synth(synthchains)
     synth_quantile = synthchains.quantile([0.159, 0.5, 0.841])
 
-    # Get quantiles and update posterior object to median 
+    # Get quantiles and update posterior object to median
     # values returned by MCMC chains
     post_summary = chains.quantile([0.159, 0.5, 0.841])
 
@@ -256,7 +256,7 @@ def mcmc(args):
 
 def ic_compare(args):
     """Compare different models and comparative statistics including
-          AICc and BIC statistics. 
+          AICc and BIC statistics.
 
     Args:
         args (ArgumentParser): command line arguments
@@ -394,7 +394,7 @@ def derive(args):
     chains = pd.read_csv(status.get('mcmc', 'chainfile'))
 
     mstar = np.random.normal(
-        loc=P.stellar['mstar'], scale=P.stellar['mstar_err'], 
+        loc=P.stellar['mstar'], scale=P.stellar['mstar_err'],
         size=len(chains)
         )
 
@@ -454,7 +454,7 @@ Interpret results with caution.".format(np.median(mpsini)))
 
         try:
             rp = np.random.normal(
-                loc=P.planet['rp{}'.format(i)], 
+                loc=P.planet['rp{}'.format(i)],
                 scale=P.planet['rp_err{}'.format(i)],
                 size=len(chains)
             )
@@ -481,7 +481,7 @@ def report(args):
     Args:
         args (ArgumentParser): command line arguments
     """
-    
+
     config_file = args.setupfn
     conf_base = os.path.basename(config_file).split('.')[0]
     print("Assembling report for {}".format(conf_base))
@@ -527,7 +527,7 @@ report.".format(args.comptype,
             rfile, depfiles=report_depfiles, latex_compiler=args.latex_compiler
         )
 
-    
+
 def save_status(statfile, section, statevars):
     """Save pipeline status
 
@@ -539,13 +539,13 @@ def save_status(statfile, section, statevars):
     """
 
     config = configparser.RawConfigParser()
-    
+
     if os.path.isfile(statfile):
         config.read(statfile)
 
     if not config.has_section(section):
         config.add_section(section)
-        
+
     for key, val in statevars.items():
         config.set(section, key, val)
 
@@ -562,7 +562,7 @@ def load_status(statfile):
     Returns:
         configparser.RawConfigParser
     """
-    
+
     config = configparser.RawConfigParser()
     gl = config.read(statfile)
 

--- a/radvel/fitting.py
+++ b/radvel/fitting.py
@@ -20,7 +20,7 @@ def maxlike_fitting(post, verbose=True, method='Powell'):
         method (string [optional]): Minimization method. See documentation for `scipy.optimize.minimize` for available
             options.
 
-    Returns: 
+    Returns:
         radvel.Posterior : Posterior object with parameters
         updated to their maximum a posteriori values
 
@@ -41,9 +41,9 @@ def maxlike_fitting(post, verbose=True, method='Powell'):
         print("Final loglikelihood = %f" % post.logprob())
         print("Best-fit parameters:")
         print(post)
-        
+
     return post
-    
+
 
 def model_comp(post, params=[], mc_list=[], verbose=False):
     """Model Comparison
@@ -52,18 +52,18 @@ def model_comp(post, params=[], mc_list=[], verbose=False):
     Save results as list of dictionaries of posterior statistics.
 
     Args:
-        post (radvel.Posterior): posterior object for final best-fit solution 
+        post (radvel.Posterior): posterior object for final best-fit solution
             with all planets
         params (list of strings): (optional) type of comparison to make via bic/aic
         mc_list (list of OrderedDicts): (optional) list of dictionaries from different
             model comparisons. Each value in the dictionary is a tuple with a statistic
             as the first element and a description as the second element.
         verbose (bool): (optional) print out statistics
-        
+
     Returns:
-        list of OrderedDicts: 
-            List of dictionaries with fit statistics. Each value in the 
-            dictionary is a tuple with the statistic value as the first 
+        list of OrderedDicts:
+            List of dictionaries with fit statistics. Each value in the
+            dictionary is a tuple with the statistic value as the first
             element and a description of that statistic in the second element.
     """
 
@@ -72,18 +72,18 @@ def model_comp(post, params=[], mc_list=[], verbose=False):
     assert isinstance(mc_list, list), \
         "mc_list must be either an empty list or a list of model comparison dictionaries"
     assert isinstance(params, list), \
-        "The params argument must contain a list of parameters for model comparison." 
+        "The params argument must contain a list of parameters for model comparison."
 
     valid_mc_args = ['e', 'nplanets', 'trend', 'jit', 'gp']
-    for element in params: 
+    for element in params:
         assert element in valid_mc_args, \
             "The valid model comparison strings in the params argument are: " \
             + ", ".join(valid_mc_args)
 
     # If there are no parameters to compare simply do a maximum likelihood fit
-    #   to get BIC and AIC values among other diagnostics. 
+    #   to get BIC and AIC values among other diagnostics.
     if not params:
-        
+
         fitpost = maxlike_fitting(post, verbose=verbose)
 
         ndata = len(fitpost.likelihood.y)
@@ -101,14 +101,14 @@ def model_comp(post, params=[], mc_list=[], verbose=False):
             print("chi_red = %4.2f" % chi_red)
             print("BIC = %4.2f" % fitpost.likelihood.bic())
             print("AIC = %4.2f" % fitpost.likelihood.aic())
-       
+
         comparison_parameters = ['Free Params', '$N_{\\rm free}$', '$N_{\\rm data}$',
                                  'RMS', '$\\ln{\\mathcal{L}}$', 'BIC', 'AICc']
         pdict = collections.OrderedDict.fromkeys(comparison_parameters)
         pdict['$N_{\\rm data}$'] = (ndata, 'number of measurements')
         pdict['$N_{\\rm free}$'] = (nfree, 'number of free parameters')
         pdict['RMS'] = (
-            np.round(np.std(fitpost.likelihood.residuals()), 2), 
+            np.round(np.std(fitpost.likelihood.residuals()), 2),
             'RMS of residuals in m s$^{-1}$'
         )
         # pdict['$\\chi^{2}$'] = (np.round(chi,2), "jitter fixed")
@@ -136,7 +136,7 @@ def model_comp(post, params=[], mc_list=[], verbose=False):
         lcparam = len(circparam)
         planet_letters = fitpost.likelihood.params.planet_letters
         if planet_letters is None:
-            planet_letters = [ALPHABET[i] for i in range(num_planets+1)] 
+            planet_letters = [ALPHABET[i] for i in range(num_planets+1)]
         jitterchecked = False
         for pari in fitpost.params:
             if (len(pari) >= lcparam) and (pari[0:lcparam] == circparam) and fitpost.params[pari].vary:
@@ -159,11 +159,11 @@ def model_comp(post, params=[], mc_list=[], verbose=False):
         mc_list.append(pdict)
         return mc_list
 
-    # Otherwise parse the different parameter comparison options and perform a maximum 
+    # Otherwise parse the different parameter comparison options and perform a maximum
     #   likelihood model comparison for each case
-    
-    elif 'gp' in params: 
-        newparams = [pi for pi in params if pi != 'gp'] 
+
+    elif 'gp' in params:
+        newparams = [pi for pi in params if pi != 'gp']
         if isinstance(post.likelihood, radvel.likelihood.GPLikelihood):
             print("Warning: BIC/AIC comparisons with and without GP are only implemented for "
                   + "kernels where the amplitude of the GP is described by the 'gp_amp' "
@@ -191,7 +191,7 @@ def model_comp(post, params=[], mc_list=[], verbose=False):
     elif 'jit' in params:
         ipost = copy.deepcopy(post)
         cpost = copy.deepcopy(ipost)
-        newparams = [pi for pi in params if pi != 'jit'] 
+        newparams = [pi for pi in params if pi != 'jit']
         anyjitteron = False
         for parami in ipost.params:
             if len(parami) >= 3 and parami[:3] == 'jit' and ipost.params[parami].vary:
@@ -209,7 +209,7 @@ def model_comp(post, params=[], mc_list=[], verbose=False):
 
     elif 'trend' in params:
         ipost = copy.deepcopy(post)
-        newparams = [pi for pi in params if pi != 'trend'] 
+        newparams = [pi for pi in params if pi != 'trend']
         trendparamlist = ['curv', 'dvdt']
         anytrendparam = False
         for cparam in trendparamlist:
@@ -229,15 +229,15 @@ def model_comp(post, params=[], mc_list=[], verbose=False):
     elif 'nplanets' in params:
         eparams = post.params.basis.get_eparams()
         circparams = post.params.basis.get_circparams()
-        allparams = eparams+circparams  
+        allparams = eparams+circparams
 
         ipost = copy.deepcopy(post)
-        newparams = [pi for pi in params if pi != 'nplanets'] 
+        newparams = [pi for pi in params if pi != 'nplanets']
         num_planets = post.likelihood.model.num_planets
         pllist = [pl+1 for pl in range(num_planets)]
         plgroups = ()
         for p in [pl+1 for pl in range(num_planets)]:
-            plgroups = itertools.chain(plgroups, itertools.combinations(pllist, p)) 
+            plgroups = itertools.chain(plgroups, itertools.combinations(pllist, p))
         plparams = []
         for plgroup in plgroups:
             suffixes = [str(pl) for pl in plgroup]
@@ -260,12 +260,12 @@ def model_comp(post, params=[], mc_list=[], verbose=False):
         eparams = post.params.basis.get_eparams()
 
         ipost = copy.deepcopy(post)
-        newparams = [pi for pi in params if pi != 'e'] 
+        newparams = [pi for pi in params if pi != 'e']
         num_planets = post.likelihood.model.num_planets
         pllist = [pl+1 for pl in range(num_planets)]
         plgroups = ()
         for p in [pl+1 for pl in range(num_planets)]:
-            plgroups = itertools.chain(plgroups, itertools.combinations(pllist, p)) 
+            plgroups = itertools.chain(plgroups, itertools.combinations(pllist, p))
         plparams = []
         for plgroup in plgroups:
             suffixes = [str(pl) for pl in plgroup]

--- a/radvel/gp.py
+++ b/radvel/gp.py
@@ -128,7 +128,7 @@ class SqExpKernel(Kernel):
                 errors (float or numpy array): If covariance matrix is non-square,
                     this arg must be set to 0. If covariance matrix is square,
                     this can be a numpy array of observational errors and jitter
-                    added in quadrature. 
+                    added in quadrature.
         """
         length = self.hparams['gp_length'].value
         amp = self.hparams['gp_amp'].value
@@ -214,7 +214,7 @@ class PerKernel(Kernel):
                 errors (float or numpy array): If covariance matrix is non-square,
                     this arg must be set to 0. If covariance matrix is square,
                     this can be a numpy array of observational errors and jitter
-                    added in quadrature. 
+                    added in quadrature.
         """
         length= self.hparams['gp_length'].value
         amp = self.hparams['gp_amp'].value
@@ -244,7 +244,7 @@ class QuasiPerKernel(Kernel):
         hparams (dict of radvel.Parameter): dictionary containing
             radvel.Parameter objects that are GP hyperparameters
             of this kernel. Must contain exactly four objects, 'gp_explength*',
-            'gp_amp*', 'gp_per*', and 'gp_perlength*', where * is a suffix 
+            'gp_amp*', 'gp_per*', and 'gp_perlength*', where * is a suffix
             identifying these hyperparameters with a likelihood object.
 
     """
@@ -289,7 +289,7 @@ class QuasiPerKernel(Kernel):
         explength = self.hparams['gp_explength'].value
 
         msg = (
-            "QuasiPer Kernel with amp: {}, per length: {}, per: {}, " 
+            "QuasiPer Kernel with amp: {}, per length: {}, per: {}, "
             "exp length: {}"
         ).format(amp, perlength, per, explength)
         return msg
@@ -308,7 +308,7 @@ class QuasiPerKernel(Kernel):
                 errors (float or numpy array): If covariance matrix is non-square,
                     this arg must be set to 0. If covariance matrix is square,
                     this can be a numpy array of observational errors and jitter
-                    added in quadrature. 
+                    added in quadrature.
         """
         perlength = self.hparams['gp_perlength'].value
         amp = self.hparams['gp_amp'].value
@@ -351,7 +351,7 @@ class CeleriteKernel(Kernel):
         hparams (dict of radvel.Parameter): dictionary containing
             radvel.Parameter objects that are GP hyperparameters
             of this kernel. Must contain exactly four objects, 'gp_B*',
-            'gp_C*', 'gp_L*', and 'gp_Prot*', where * is a suffix 
+            'gp_C*', 'gp_L*', and 'gp_Prot*', where * is a suffix
             identifying these hyperparameters with a likelihood object.
     """
 
@@ -421,9 +421,9 @@ CeleriteKernel requires hyperparameters 'gp_B*', 'gp_C*', 'gp_L', and 'gp_Prot*'
 
     def compute_distances(self, x1, x2):
         """
-        The celerite.solver.CholeskySolver object does 
-        not require distances to be precomputed, so 
-        this method has been co-opted to define some 
+        The celerite.solver.CholeskySolver object does
+        not require distances to be precomputed, so
+        this method has been co-opted to define some
         unchanging variables.
         """
         self.x = x1
@@ -450,9 +450,9 @@ CeleriteKernel requires hyperparameters 'gp_B*', 'gp_C*', 'gp_L', and 'gp_Prot*'
 
         self.compute_real_and_complex_hparams()
         solver.compute(
-            0., self.real[:,0], self.real[:,2], 
-            self.complex[:,0], self.complex[:,1], 
-            self.complex[:,2], self.complex[:,3], 
+            0., self.real[:,0], self.real[:,2],
+            self.complex[:,0], self.complex[:,1],
+            self.complex[:,2], self.complex[:,3],
             self.A, self.U, self.V,
             self.x, errors**2
         )

--- a/radvel/kepler.py
+++ b/radvel/kepler.py
@@ -4,7 +4,7 @@ import radvel
 
 # Try to import Kepler's equation solver written in C
 try:
-    from . import _kepler 
+    from . import _kepler
     cext = True
 except ImportError:
     print("WARNING: KEPLER: Unable to import C-based Kepler's\
@@ -14,7 +14,7 @@ equation solver. Falling back to the slower NumPy implementation.")
 
 def rv_drive(t, orbel, use_c_kepler_solver=cext):
     """RV Drive
-    
+
     Args:
         t (array of floats): times of observations
         orbel (array of floats): [per, tp, e, om, K].\
@@ -25,12 +25,12 @@ def rv_drive(t, orbel, use_c_kepler_solver=cext):
             use the Python/NumPy version.
     Returns:
         rv: (array of floats): radial velocity model
-    
+
     """
-    
+
     # unpack array of parameters
     per, tp, e, om, k = orbel
-    
+
     # Performance boost for circular orbits
     if e == 0.0:
         m = 2 * np.pi * (((t - tp) / per) - np.floor((t - tp) / per))
@@ -49,7 +49,7 @@ def rv_drive(t, orbel, use_c_kepler_solver=cext):
     else:
         nu = radvel.orbit.true_anomaly(t, tp, per, e)
         rv = k * (np.cos(nu + om) + e * np.cos(om))
-    
+
     return rv
 
 
@@ -62,22 +62,22 @@ def kepler(Marr, eccarr):
 
     Returns:
         array: eccentric anomaly
-    
+
     """
-    
+
     conv = 1.0e-12  # convergence criterion
     k = 0.85
 
     Earr = Marr + np.sign(np.sin(Marr)) * k * eccarr  # first guess at E
     # fiarr should go to zero when converges
-    fiarr = ( Earr - eccarr * np.sin(Earr) - Marr)  
+    fiarr = ( Earr - eccarr * np.sin(Earr) - Marr)
     convd = np.where(np.abs(fiarr) > conv)[0]  # which indices have not converged
     nd = len(convd)  # number of unconverged elements
     count = 0
 
     while nd > 0:  # while unconverged elements exist
         count += 1
-        
+
         M = Marr[convd]  # just the unconverged elements ...
         ecc = eccarr[convd]
         E = Earr[convd]
@@ -88,7 +88,7 @@ def kepler(Marr, eccarr):
         fippp = 1 - fip  # d/dE(d/dE(d/dE(fi))) ;i.e.,  fi^(\prime\prime\prime)
 
         # first, second, and third order corrections to E
-        d1 = -fi / fip 
+        d1 = -fi / fip
         d2 = -fi / (fip + d1 * fipp / 2.0)
         d3 = -fi / (fip + d2 * fipp / 2.0 + d2 * d2 * fippp / 6.0)
         E = E + d3
@@ -96,10 +96,10 @@ def kepler(Marr, eccarr):
         fiarr = ( Earr - eccarr * np.sin( Earr ) - Marr) # how well did we do?
         convd = np.abs(fiarr) > conv  # test for convergence
         nd = np.sum(convd is True)
-        
-    if Earr.size > 1: 
+
+    if Earr.size > 1:
         return Earr
-    else: 
+    else:
         return Earr[0]
 
 
@@ -108,7 +108,7 @@ def profile():
     # Python/Numpy implementation
 
     import timeit
-    
+
     ecc = 0.1
     numloops = 5000
     print("\nECCENTRICITY = {}".format(ecc))

--- a/radvel/likelihood.py
+++ b/radvel/likelihood.py
@@ -9,7 +9,7 @@ _has_celerite = gp._try_celerite()
 if _has_celerite:
     import celerite
 
-    
+
 def custom_formatwarning(msg, *args, **kwargs):
     # ignore everything except the message
     return str(msg) + '\n'
@@ -46,7 +46,7 @@ class Likelihood(object):
                 )
             keys = self.params.keys()
             for key in keys:
-                vstr = str(self.params[key].vary)    
+                vstr = str(self.params[key].vary)
                 if (key.startswith('tc') or key.startswith('tp')) and self.params[key].value > 1e6:
                     par = self.params[key].value - 2450000
                 else:
@@ -72,7 +72,7 @@ class Likelihood(object):
                     par = self.params[key].value - 2450000
                 else:
                     par = self.params[key].value
-                    
+
                 s += "{:20s}{:15g}{:10g}{:>10s}\n".format(
                     key, par, err, vstr
                      )
@@ -94,7 +94,7 @@ class Likelihood(object):
         params_array = []
         for key in self.list_vary_params():
             if self.params[key].vary:
-                params_array += [self.params[key].value]     
+                params_array += [self.params[key].value]
         params_array = np.array(params_array)
         return params_array
 
@@ -187,10 +187,10 @@ class CompositeLikelihood(Likelihood):
         self.extra_params = like0.extra_params
         self.suffixes = like0.suffix
         self.uparams = like0.uparams
-        
+
         for i in range(1, self.nlike):
             like = like_list[i]
-            
+
             self.x = np.append(self.x, like.x)
             self.y = np.append(self.y, like.y - like.params[like.gamma_param].value)
             self.yerr = np.append(self.yerr, like.yerr)
@@ -201,7 +201,7 @@ class CompositeLikelihood(Likelihood):
                 self.uparams = self.uparams.update(like.uparams)
             except AttributeError:
                 self.uparams = None
-            
+
             assert like.model is like0.model, \
                 "Likelihoods must use the same model"
 
@@ -214,7 +214,7 @@ class CompositeLikelihood(Likelihood):
         self.extra_params = list(set(self.extra_params))
         self.params = params
         self.like_list = like_list
-        
+
     def logprob(self):
         """
         See `radvel.likelihood.RVLikelihood.logprob`
@@ -234,7 +234,7 @@ class CompositeLikelihood(Likelihood):
             res = np.append(res, like.residuals())
 
         return res
-        
+
     def errorbars(self):
         """
         See `radvel.likelihood.RVLikelihood.errorbars`
@@ -272,7 +272,7 @@ class RVLikelihood(Likelihood):
             self.suffix = suffix
 
         self.telvec = np.array([self.suffix]*len(t))
-        
+
         self.decorr_params = []
         self.decorr_vectors = decorr_vectors
         if len(decorr_vars) > 0:
@@ -291,7 +291,7 @@ class RVLikelihood(Likelihood):
         mod = self.model(self.x)
 
         res = self.y - self.params[self.gamma_param].value - mod
-        
+
         if len(self.decorr_params) > 0:
             for parname in self.decorr_params:
                 var = parname.split('_')[1]
@@ -313,7 +313,7 @@ class RVLikelihood(Likelihood):
 
         Returns:
             array: uncertainties
-        
+
         """
         return np.sqrt(self.yerr**2 + self.params[self.jit_param].value**2)
 
@@ -343,18 +343,18 @@ class GPLikelihood(RVLikelihood):
         t (array): time array
         vel (array): array of velocities
         errvel (array): array of velocity uncertainties
-        hnames (list of string): keys corresponding to radvel.Parameter 
+        hnames (list of string): keys corresponding to radvel.Parameter
            objects in model.params that are GP hyperparameters
         suffix (string): suffix to identify this Likelihood object;
            useful when constructing a `CompositeLikelihood` object
     """
-    def __init__(self, model, t, vel, errvel, 
+    def __init__(self, model, t, vel, errvel,
                  hnames=['gp_per', 'gp_perlength', 'gp_explength', 'gp_amp'],
                  suffix='', kernel_name="QuasiPer", **kwargs):
 
         self.suffix = suffix
         super(GPLikelihood, self).__init__(
-              model, t, vel, errvel, suffix=self.suffix, 
+              model, t, vel, errvel, suffix=self.suffix,
               decorr_vars=[], decorr_vectors={}
             )
         assert kernel_name in gp.KERNELS.keys(), \
@@ -364,17 +364,17 @@ class GPLikelihood(RVLikelihood):
         self.hnames = hnames  # list of string names of hyperparameters
         self.hyperparams = {k: self.params[k] for k in self.hnames}
 
-        self.kernel_call = getattr(gp, kernel_name + "Kernel") 
+        self.kernel_call = getattr(gp, kernel_name + "Kernel")
         self.kernel = self.kernel_call(self.hyperparams)
 
         self.kernel.compute_distances(self.x, self.x)
         self.N = len(self.x)
 
     def update_kernel_params(self):
-        """ Update the Kernel object with new values of the hyperparameters 
+        """ Update the Kernel object with new values of the hyperparameters
         """
         for key in self.list_vary_params():
-            if key in self.hnames: 
+            if key in self.hnames:
                 hparams_key = key.split('_')
                 hparams_key = hparams_key[0] + '_' + hparams_key[1]
                 self.kernel.hparams[hparams_key].value = self.params[key].value
@@ -405,11 +405,11 @@ class GPLikelihood(RVLikelihood):
         .. math::
 
            lnL = -0.5r^TK^{-1}r - 0.5ln[det(K)] - 0.5N*ln(2pi)
-           
-        where r = vector of residuals (GPLikelihood._resids), 
-        K = covariance matrix, and N = number of datapoints. 
 
-        Priors are not applied here. 
+        where r = vector of residuals (GPLikelihood._resids),
+        K = covariance matrix, and N = number of datapoints.
+
+        Priors are not applied here.
         Constant has been omitted.
 
         Returns:
@@ -419,7 +419,7 @@ class GPLikelihood(RVLikelihood):
         # update the Kernel object hyperparameter values
         self.update_kernel_params()
 
-        r = self._resids()      
+        r = self._resids()
 
         self.kernel.compute_covmatrix(self.errorbars())
 
@@ -477,7 +477,7 @@ class GPLikelihood(RVLikelihood):
         self.kernel.compute_distances(self.x, self.x)
 
         return mu, stdev
-        
+
 
 class CeleriteLikelihood(GPLikelihood):
     """Celerite GP Likelihood
@@ -496,7 +496,7 @@ class CeleriteLikelihood(GPLikelihood):
         t (array): time array
         vel (array): array of velocities
         errvel (array): array of velocity uncertainties
-        hnames (list of string): keys corresponding to radvel.Parameter 
+        hnames (list of string): keys corresponding to radvel.Parameter
            objects in model.params that are GP hyperparameters
         suffix (string): suffix to identify this Likelihood object;
            useful when constructing a `CompositeLikelihood` object
@@ -525,7 +525,7 @@ class CeleriteLikelihood(GPLikelihood):
 
             # calculate log likelihood
             lnlike = -0.5 * (solver.dot_solve(self._resids()) + solver.log_determinant() + self.N*np.log(2.*np.pi))
-        
+
             return lnlike
 
         except celerite.solver.LinAlgError:
@@ -581,10 +581,10 @@ def loglike_jitter(residuals, sigma, sigma_jit):
     """
     Log-likelihood incorporating jitter
 
-    See equation (1) in Howard et al. 2014. Returns loglikelihood, where 
+    See equation (1) in Howard et al. 2014. Returns loglikelihood, where
     sigma**2 is replaced by sigma**2 + sigma_jit**2. It penalizes
     excessively large values of jitter
-    
+
     Args:
         residuals (array): array of residuals
         sigma (array): array of measurement errors
@@ -597,5 +597,5 @@ def loglike_jitter(residuals, sigma, sigma_jit):
     penalty = np.sum( np.log( np.sqrt( 2 * np.pi * sum_sig_quad ) ) )
     chi2 = np.sum(residuals**2 / sum_sig_quad)
     loglike = -0.5 * chi2 - penalty
-    
+
     return loglike

--- a/radvel/mcmc.py
+++ b/radvel/mcmc.py
@@ -32,7 +32,7 @@ def _status_message(statevars):
 def convergence_check(maxGR, minTz, minsteps, minpercent):
     """Check for convergence
     Check for convergence for a list of emcee samplers
-    
+
     Args:
         maxGR (float): Maximum G-R statistic for chains to be deemed well-mixed and halt the MCMC run
         minTz (int): Minimum Tz to consider well-mixed
@@ -41,7 +41,7 @@ def convergence_check(maxGR, minTz, minsteps, minpercent):
         minpercent (float): Minimum percentage of total steps before convergence tests are performed. Convergence checks
             will start after the minsteps threshold or the minpercent threshold has been hit.
     """
-    
+
     statevars.ar = 0
     statevars.ncomplete = statevars.nburn
     statevars.tchains = np.empty((statevars.ndim,
@@ -80,7 +80,7 @@ def convergence_check(maxGR, minTz, minsteps, minpercent):
 
 def _domcmc(input_tuple):
     """Function to be run in parallel on different CPUs
-    Input is a tuple: first element is an emcee sampler object, second is an array of 
+    Input is a tuple: first element is an emcee sampler object, second is an array of
     initial positions, third is number of steps to run before doing a convergence check
     """
     sampler = input_tuple[0]
@@ -119,7 +119,7 @@ def mcmc(post, nwalkers=50, nrun=10000, ensembles=8, checkinterval=50, burnGR=1.
     if isinstance(post.likelihood, radvel.likelihood.CompositeLikelihood):
         check_gp = [like for like in post.likelihood.like_list if isinstance(like, radvel.likelihood.GPLikelihood)]
     else:
-        check_gp = isinstance(post.likelihood, radvel.likelihood.GPLikelihood)  
+        check_gp = isinstance(post.likelihood, radvel.likelihood.GPLikelihood)
 
     np_info = np.__config__.blas_opt_info
     if 'extra_link_args' in np_info.keys() \
@@ -134,9 +134,9 @@ def mcmc(post, nwalkers=50, nrun=10000, ensembles=8, checkinterval=50, burnGR=1.
     statevars.ensembles = ensembles
     statevars.nwalkers = nwalkers
     statevars.checkinterval = checkinterval
-    
+
     nrun = int(nrun)
-        
+
     # Get an initial array value
     pi = post.get_vary_params()
     statevars.ndim = pi.size
@@ -173,7 +173,7 @@ of free parameters. Adjusting number of walkers to {}".format(2*statevars.ndim))
         p0 = np.vstack([pi]*statevars.nwalkers)
         p0 += [np.random.rand(statevars.ndim)*pscales for i in range(statevars.nwalkers)]
         statevars.initial_positions.append(p0)
-        statevars.samplers.append(emcee.EnsembleSampler( 
+        statevars.samplers.append(emcee.EnsembleSampler(
             statevars.nwalkers, statevars.ndim, post.logprob_array, threads=1))
 
     num_run = int(np.round(nrun / checkinterval))
@@ -244,19 +244,19 @@ of free parameters. Adjusting number of walkers to {}".format(2*statevars.ndim))
             break
 
     print("\n")
-    if statevars.ismixed and statevars.mixcount < 5: 
+    if statevars.ismixed and statevars.mixcount < 5:
         msg = (
             "MCMC: WARNING: chains did not pass 5 consecutive convergence "
             "tests. They may be marginally well=mixed."
         )
         print(msg)
-    elif not statevars.ismixed: 
+    elif not statevars.ismixed:
         msg = (
             "MCMC: WARNING: chains did not pass convergence tests. They are "
             "likely not well-mixed."
         )
         print(msg)
-        
+
     df = pd.DataFrame(
         statevars.tchains.reshape(statevars.ndim, statevars.tchains.shape[1]*statevars.tchains.shape[2]).transpose(),
         columns=post.list_vary_params())
@@ -284,21 +284,21 @@ def gelman_rubin(pars0, minTz, maxGR):
             consider well-mixed
     Returns:
         tuple: tuple containing:
-            ismixed (bool): 
+            ismixed (bool):
                 Are the chains well-mixed?
-            gelmanrubin (array): 
+            gelmanrubin (array):
                 An NPARS element array containing the
                 Gelman-Rubin statistic for each parameter (equation
                 25)
-            Tz (array): 
+            Tz (array):
                 An NPARS element array containing the number
                 of independent draws for each parameter (equation 26)
-                
-    History: 
+
+    History:
         2010/03/01:
-            Written: Jason Eastman - The Ohio State University   
+            Written: Jason Eastman - The Ohio State University
         2012/10/08:
-            Ported to Python by BJ Fulton - University of Hawaii, 
+            Ported to Python by BJ Fulton - University of Hawaii,
             Institute for Astronomy
         2016/04/20:
             Adapted for use in RadVel. Removed "angular" parameter.
@@ -307,10 +307,10 @@ def gelman_rubin(pars0, minTz, maxGR):
 
 
     pars = pars0.copy() # don't modify input parameters
-    
+
     sz = pars.shape
     msg = 'MCMC: GELMAN_RUBIN: ERROR: pars must have 3 dimensions'
-    assert pars.ndim == 3, msg 
+    assert pars.ndim == 3, msg
 
     npars = float(sz[0])
     nsteps = float(sz[1])
@@ -323,16 +323,16 @@ def gelman_rubin(pars0, minTz, maxGR):
     variances = np.var(pars,axis=1, dtype=np.float64)
     meanofvariances = np.mean(variances,axis=1)
     withinChainVariances = np.mean(variances, axis=1)
-    
+
     # Equation 23: B(z) in Ford 2006
     means = np.mean(pars,axis=1)
     betweenChainVariances = np.var(means,axis=1, dtype=np.float64) * nsteps
     varianceofmeans = np.var(means,axis=1, dtype=np.float64) / (nchains-1)
     varEstimate = (
-        (1.0 - 1.0/nsteps) * withinChainVariances 
+        (1.0 - 1.0/nsteps) * withinChainVariances
         + 1.0 / nsteps * betweenChainVariances
     )
-    
+
     bz = varianceofmeans * nsteps
 
     # Equation 24: varhat+(z) in Ford 2006
@@ -349,5 +349,5 @@ def gelman_rubin(pars0, minTz, maxGR):
 
     # well-mixed criteria
     ismixed = min(tz) > minTz and max(gelmanrubin) < maxGR
-        
+
     return (ismixed, gelmanrubin, tz)

--- a/radvel/model.py
+++ b/radvel/model.py
@@ -44,19 +44,19 @@ class Parameters(OrderedDict):
 
     Args:
         num_planets (int): Number of planets in model
-        basis (string): parameterization of orbital parameters. See 
+        basis (string): parameterization of orbital parameters. See
             ``radvel.basis.Basis`` for a list of valid basis strings.
-        planet_letters (dict [optional): custom map to match the planet 
+        planet_letters (dict [optional): custom map to match the planet
             numbers in the Parameter object to planet letters.
-            Default {1: 'b', 2: 'c', etc.}. The keys of this dictionary must 
+            Default {1: 'b', 2: 'c', etc.}. The keys of this dictionary must
             all be integers.
 
     Attributes:
         basis (radvel.Basis): Basis object
-        planet_parameters (list): orbital parameters contained within the 
+        planet_parameters (list): orbital parameters contained within the
             specified basis
         num_planets (int): number of planets in the model
-    
+
     Examples:
        >>> import radvel
        # create a Parameters object for a 2-planet system with
@@ -64,7 +64,7 @@ class Parameters(OrderedDict):
        >>> params = radvel.Parameters(2, planet_letters={1:'d', 2:'e'})
 
     """
-    def __init__(self, num_planets, basis='per tc secosw sesinw logk', 
+    def __init__(self, num_planets, basis='per tc secosw sesinw logk',
                  planet_letters=None):
         super(Parameters, self).__init__()
 
@@ -75,7 +75,7 @@ class Parameters(OrderedDict):
             for parameter in self.planet_parameters:
                 new_name = self._sparameter(parameter, num_planet)
                 self.__setitem__(new_name, Parameter())
-                
+
         if planet_letters is not None:
             for k in planet_letters.keys():
                 assert isinstance(k, int), """\
@@ -99,7 +99,7 @@ should have only integers as keys."""
 
         Args:
             param_list (list [optional]): Manually pass a list of parameter labels
-        
+
         Returns:
             dict: dictionary mapping Parameters keys to TeX code
 
@@ -107,7 +107,7 @@ should have only integers as keys."""
 
         if param_list is None:
             param_list = self.keys()
-        
+
         tex_labels = {}
         for k in param_list:
             n = k[-1]
@@ -127,17 +127,17 @@ should have only integers as keys."""
                 tex_labels[k] = k
 
         return tex_labels
-        
+
     def _sparameter(self, parameter, num_planet):
         return '{0}{1}'.format(parameter, num_planet)
 
-    def _planet_texlabel(self, parameter, num_planet):        
+    def _planet_texlabel(self, parameter, num_planet):
         pname = texdict.get(parameter, parameter)
         if self.planet_letters is not None:
             lett_planet = self.planet_letters[int(num_planet)]
         else:
             lett_planet = chr(int(num_planet)+97)
-        return '$%s_{%s}$' % (pname, lett_planet) 
+        return '$%s_{%s}$' % (pname, lett_planet)
 
 
 
@@ -146,7 +146,7 @@ class Parameter(object):
     """Object to store attributes of each orbital parameter
 
     Attributes:
-        value (float): value of parameter. 
+        value (float): value of parameter.
         vary (Bool): True if parameter is allowed to vary in
             MCMC or max likelihood fits, false if fixed
         mcmcscale (float): step size to be used for MCMC fitting
@@ -193,12 +193,12 @@ class RVModel(object):
 
     def __call__(self, t, planet_num=None):
         """Compute the radial velocity.
-        
+
         Includes all Keplerians and additional trends.
 
         Args:
             t (array of floats): Timestamps to calculate the RV model
-            planet_num (int [optional]): calculate the RV model for a single 
+            planet_num (int [optional]): calculate the RV model for a single
                 planet within a multi-planet system
 
         Returns:
@@ -206,12 +206,12 @@ class RVModel(object):
         """
         vel = np.zeros(len(t))
         params_synth = self.params.basis.to_synth(self.params)
-        
+
         if planet_num is None:
             planets = range(1, self.num_planets+1)
         else:
             planets = [planet_num]
-        
+
         for num_planet in planets:
             per = params_synth['per{}'.format(num_planet)].value
             tp = params_synth['tp{}'.format(num_planet)].value

--- a/radvel/orbit.py
+++ b/radvel/orbit.py
@@ -8,11 +8,11 @@ def timetrans_to_timeperi(tc, per, ecc, omega):
     Convert Time of Transit to Time of Periastron Passage
 
     Args:
-        tc (float): time of transit    
+        tc (float): time of transit
         per (float): period [days]
         ecc (float): eccentricity
         omega (float): longitude of periastron (radians)
-    
+
     Returns:
         float: time of periastron passage
 
@@ -22,13 +22,13 @@ def timetrans_to_timeperi(tc, per, ecc, omega):
             return tc
     except ValueError:
         pass
-    
+
     f = np.pi/2 - omega
     ee = 2 * np.arctan(np.tan(f/2) * np.sqrt((1-ecc)/(1+ecc)))  # eccentric anomaly
     tp = tc - per/(2*np.pi) * (ee - ecc*np.sin(ee))      # time of periastron
-    
+
     return tp
-    
+
 
 def timeperi_to_timetrans(tp, per, ecc, omega, secondary=False):
     """
@@ -43,14 +43,14 @@ def timeperi_to_timetrans(tp, per, ecc, omega, secondary=False):
 
     Returns:
         float: time of inferior conjunction (time of transit if system is transiting)
-    
+
     """
     try:
         if ecc >= 1:
             return tp
     except ValueError:
         pass
-    
+
     if secondary:
         f = 3*np.pi/2 - omega                                       # true anomaly during secondary eclipse
         ee = 2 * np.arctan(np.tan(f/2) * np.sqrt((1-ecc)/(1+ecc)))  # eccentric anomaly

--- a/radvel/posterior.py
+++ b/radvel/posterior.py
@@ -19,7 +19,7 @@ class Posterior(Likelihood):
         Append `radvel.prior.Prior` objects to the Posterior.priors list
         to apply priors in the likelihood calculations.
     """
-    
+
     def __init__(self,likelihood):
         self.likelihood = likelihood
         self.params = likelihood.params
@@ -27,7 +27,7 @@ class Posterior(Likelihood):
         self.priors = []
 
         self.vparams_order = self.list_vary_params()
-    
+
     def __repr__(self):
         s = super(Posterior, self).__repr__()
         s += "\nPriors\n"
@@ -35,7 +35,7 @@ class Posterior(Likelihood):
         for prior in self.priors:
             s += prior.__repr__() + "\n"
         return s
-    
+
     def logprob(self):
         """Log probability
 
@@ -45,11 +45,11 @@ class Posterior(Likelihood):
         Returns:
             float: log probability of the likelihood + priors
         """
-            
+
         _logprob = self.likelihood.logprob()
         for prior in self.priors:
             _logprob += prior(self.params)
-            
+
         return _logprob
 
     def logprob_array(self, param_values_array):

--- a/radvel/prior.py
+++ b/radvel/prior.py
@@ -24,7 +24,7 @@ class Gaussian(Prior):
         mu (float): center of Gaussian prior
         sigma (float): width of Gaussian prior
     """
-    
+
     def __init__(self, param, mu, sigma):
         self.mu = mu
         self.sigma = sigma
@@ -43,11 +43,11 @@ class Gaussian(Prior):
     def __str__(self):
         try:
             tex = model.Parameters(9).tex_labels(param_list=[self.param])[self.param]
-            
+
             s = "Gaussian prior on {}: ${} \\pm {}$ \\\\".format(tex, self. mu, self.sigma)
         except KeyError:
             s = self.__repr__()
-            
+
         return s
 
 
@@ -73,7 +73,7 @@ class EccentricityPrior(Prior):
             msg += "e{} constrained to be < {}\n".format(num_planet, self.upperlims[i])
 
         return msg[:-1]
-    
+
     def __str__(self):
         tex = model.Parameters(9, basis='per tc e w k').tex_labels()
 
@@ -84,7 +84,7 @@ class EccentricityPrior(Prior):
             msg += "{} constrained to be $<{}$ \\\\\\\\\n".format(label, self.upperlims[i])
 
         return msg[:-5]
-        
+
     def __init__(self, num_planets, upperlims=0.99):
 
         if type(num_planets) == int:
@@ -93,27 +93,27 @@ class EccentricityPrior(Prior):
         else:
             self.planet_list = num_planets
             npl = num_planets
-            
+
         if type(upperlims) == float:
             self.upperlims = [upperlims] * npl
         else:
             assert len(upperlims) == len(self.planet_list), "Number of eccentricity \
 upper limits must match number of planets."
             self.upperlims = upperlims
-    
+
     def __call__(self, params):
         def _getpar(key, num_planet):
             return params['{}{}'.format(key, num_planet)].value
 
         parnames = params.basis.name.split()
-        
+
         for i, num_planet in enumerate(self.planet_list):
             if 'e' in parnames:
                 ecc = _getpar('e', num_planet)
             elif 'secosw' in parnames:
                 secosw = _getpar('secosw', num_planet)
                 sesinw = _getpar('sesinw', num_planet)
-                ecc = secosw**2 + sesinw**2 
+                ecc = secosw**2 + sesinw**2
             elif 'ecosw' in parnames:
                 ecosw = _getpar('ecosw', num_planet)
                 esinw = _getpar('esinw', num_planet)
@@ -124,7 +124,7 @@ upper limits must match number of planets."
 
             if ecc > self.upperlims[i] or ecc < 0.0:
                 return -np.inf
-        
+
         return -np.sum(np.log(self.upperlims))
 
 
@@ -139,7 +139,7 @@ class PositiveKPrior(Prior):
         num_planets (int): Number of planets. Used to ensure K for each
             planet is positive
     """
-    
+
     def __repr__(self):
         return "K constrained to be > 0"
 
@@ -148,7 +148,7 @@ class PositiveKPrior(Prior):
 
     def __init__(self, num_planets):
         self.num_planets = num_planets
-    
+
     def __call__(self, params):
         def _getpar(key, num_planet):
             return params['{}{}'.format(key, num_planet)].value
@@ -159,7 +159,7 @@ class PositiveKPrior(Prior):
             except KeyError:
                 k = np.exp(_getpar('logk', num_planet))
 
-            if k < 0.0:    
+            if k < 0.0:
                 return -np.inf
         return 0
 
@@ -175,7 +175,7 @@ class HardBounds(Prior):
         minval (float): minimum allowed value
         maxval (float): maximum allowed value
     """
-    
+
     def __init__(self, param, minval, maxval):
         self.minval = minval
         self.maxval = maxval
@@ -211,13 +211,13 @@ class HardBounds(Prior):
     def __str__(self):
         try:
             tex = model.Parameters(9).tex_labels(param_list=[self.param])[self.param]
-            
+
             s = "Bounded prior: ${} < {} < {}$".format(self.minval,
                                                        tex.replace('$', ''),
                                                        self.maxval)
         except KeyError:
             s = self.__repr__()
-            
+
         return s
 
 
@@ -271,7 +271,7 @@ class SecondaryEclipsePrior(Prior):
 
         return penalty
 
-      
+
 class Jeffreys(Prior):
     """Jeffrey's prior
 
@@ -287,7 +287,7 @@ class Jeffreys(Prior):
         minval (float): minimum allowed value
         maxval (float): maximum allowed value
     """
-    
+
     def __init__(self, param, minval, maxval):
         self.minval = minval
         self.maxval = maxval
@@ -300,7 +300,7 @@ class Jeffreys(Prior):
         if x < self.minval or x > self.maxval:
             return -np.inf
         else:
-            return np.log(self.normalization) - np.log(x) 
+            return np.log(self.normalization) - np.log(x)
     def __repr__(self):
         s = "Jeffrey's prior on {}, min={}, max={}".format(
             self.param, self.minval, self.maxval
@@ -309,16 +309,16 @@ class Jeffreys(Prior):
     def __str__(self):
         try:
             tex = model.Parameters(9).tex_labels(param_list=[self.param])[self.param]
-            
+
             s = "Jeffrey's prior: ${} < {} < {}$".format(self.minval,
                                                        tex.replace('$',''),
                                                        self.maxval)
         except KeyError:
             s = self.__repr__()
-            
+
         return s
 
-      
+
 class ModifiedJeffreys(Prior):
     """Modified Jeffry's prior
 
@@ -336,7 +336,7 @@ class ModifiedJeffreys(Prior):
         maxval (float): maximum allowed value
 
     """
-    
+
     def __init__(self, param, minval, maxval, kneeval):
         self.maxval = maxval
         self.param = param
@@ -361,13 +361,13 @@ class ModifiedJeffreys(Prior):
     def __str__(self):
         try:
             tex = model.Parameters(9).tex_labels(param_list=[self.param])[self.param]
-            
+
             s = "Modified Jeffrey's prior: knee = {}; ${} < {} < {}$".format(
                 self.kneeval, self.minval, tex.replace('$',''), self.maxval
                 )
         except KeyError:
             s = self.__repr__()
-            
+
         return s
 
 class NumericalPrior(Prior):
@@ -386,14 +386,14 @@ class NumericalPrior(Prior):
     a RadVel fit.
 
     Args:
-        param_list (list of str): list of parameter label(s). 
+        param_list (list of str): list of parameter label(s).
         values (numpy array of float): values of ``param`` you
-            wish to use to define this prior. For example, this 
-            might be a posterior array of values of secosw 
-            derived from transit data. In case of univariate data 
-            this is a 1-D array, otherwise a 2-D array with shape 
+            wish to use to define this prior. For example, this
+            might be a posterior array of values of secosw
+            derived from transit data. In case of univariate data
+            this is a 1-D array, otherwise a 2-D array with shape
             (# of elements in param_list, # of data points).
-        bw_method (str, scalar, or callable [optional]): see 
+        bw_method (str, scalar, or callable [optional]): see
             scipy.stats.gaussian_kde
 
     Note: the larger the input array of values, the longer it will
@@ -401,7 +401,7 @@ class NumericalPrior(Prior):
     large input arrays to speed up performance.
 
     """
-    
+
     def __init__(self, param_list, values, bw_method=None):
         self.param_list = param_list
         self.pdf_estimate = gaussian_kde(values, bw_method=bw_method)
@@ -434,21 +434,21 @@ class NumericalPrior(Prior):
                 ", defined using Gaussian kernel density estimation."
         except KeyError:
             s = self.__repr__()
-            
+
         return s
 
 
 class UserDefinedPrior(Prior):
-    """Interface for user to define a prior 
-       with an arbitrary functional form. 
+    """Interface for user to define a prior
+       with an arbitrary functional form.
 
     Args:
-        param_list (list of str): list of parameter label(s). 
+        param_list (list of str): list of parameter label(s).
         func (function): a Python function that takes in  a list
             of values (ordered as in ``param_list``), and returns
-            the corresponding log-value of a pdf. 
+            the corresponding log-value of a pdf.
         tex_rep (str): TeX-readable string representation of
-            this prior, to be passed into radvel report and 
+            this prior, to be passed into radvel report and
             plotting code.
 
     Example:
@@ -462,9 +462,9 @@ class UserDefinedPrior(Prior):
 
     Note:
         ``func`` must be properly normalized; i.e. integrating over the
-        entire parameter space must give a probability of 1. 
+        entire parameter space must give a probability of 1.
     """
-    
+
     def __init__(self, param_list, func, tex_rep):
         self.param_list = param_list
         self.func = func
@@ -487,8 +487,8 @@ class UserDefinedPrior(Prior):
         return s
 
 class Informative_Baseline_Prior(Prior):
-    """ Informative baseline prior suggested 
-    by A. Vanderburg (see Blunt et al. 2019). 
+    """ Informative baseline prior suggested
+    by A. Vanderburg (see Blunt et al. 2019).
 
     This prior follows the distribution:
 

--- a/radvel/prior.py
+++ b/radvel/prior.py
@@ -487,7 +487,7 @@ class UserDefinedPrior(Prior):
         return s
 
 
-class Informative_Baseline_Prior(Prior):
+class InformativeBaselinePrior(Prior):
     """ Informative baseline prior suggested
     by A. Vanderburg (see Blunt et al. 2019).
 

--- a/radvel/utils.py
+++ b/radvel/utils.py
@@ -75,7 +75,7 @@ Parameters in config file must be converted to fitting basis.
  but decorr_vars is not found in your setup file.")
     else:
         decorr_vars = []
-    
+
     for key in params.keys():
         if key.startswith('logjit'):
             msg = """
@@ -89,7 +89,7 @@ Converting 'logjit' to 'jit' for you now.
             del params[key]
 
     iparams = radvel.basis._copy_params(params)
-    
+
     # Make sure we don't have duplicate indicies in the DataFrame
     P.data = P.data.reset_index(drop=True)
 
@@ -126,8 +126,8 @@ Converting 'logjit' to 'jit' for you now.
         likes[inst] = liketype(
             mod, P.data.iloc[telgrps[inst]].time,
             P.data.iloc[telgrps[inst]].mnvel,
-            P.data.iloc[telgrps[inst]].errvel, hnames=hnames, suffix='_'+inst, 
-            kernel_name=kernel_name, decorr_vars=decorr_vars, 
+            P.data.iloc[telgrps[inst]].errvel, hnames=hnames, suffix='_'+inst,
+            kernel_name=kernel_name, decorr_vars=decorr_vars,
             decorr_vectors=decorr_vectors
         )
         likes[inst].params['gamma_'+inst] = iparams['gamma_'+inst]
@@ -169,10 +169,10 @@ def sigfig(med, errlow, errhigh=None):
         tuple: (med,errlow,errhigh) rounded to the lowest number of significant figures
 
     """
-    
+
     if errhigh is None:
         errhigh = errlow
-        
+
     ndec = Decimal(str(errlow)).as_tuple().exponent
     if abs(Decimal(str(errhigh)).as_tuple().exponent) > abs(ndec):
         ndec = Decimal(str(errhigh)).as_tuple().exponent
@@ -285,7 +285,7 @@ def bintels(t, vel, err, telvec, binsize=1/2.):
     if ntels == 1:
         t_bin, vel_bin, err_bin = timebin(t, vel, err, binsize=binsize)
         return t_bin, vel_bin, err_bin, telvec
-    
+
     uniqorder = np.argsort(np.unique(telvec, return_index=1)[1])
     uniqsort = np.unique(telvec)[uniqorder]
     rvtimes = np.array([])
@@ -301,7 +301,7 @@ def bintels(t, vel, err, telvec, binsize=1/2.):
         rvdat = np.hstack((rvdat, vel_bin))
         rverr = np.hstack((rverr, err_bin))
         newtelvec = np.hstack((newtelvec, np.array([tel]*len(t_bin))))
-        
+
     return rvtimes, rvdat, rverr, newtelvec
 
 
@@ -358,10 +358,10 @@ def t_to_phase(params, t, num_planet, cat=False):
         timeparam = 'tc%i' % num_planet
     elif ('tp%i' % num_planet) in params:
         timeparam = 'tp%i' % num_planet
-        
+
     P = params['per%i' % num_planet].value
     tc = params[timeparam].value
-    phase = np.mod(t - tc, P) 
+    phase = np.mod(t - tc, P)
     phase /= P
     if cat:
         phase = np.concatenate((phase, phase+1))
@@ -376,7 +376,7 @@ def working_directory(dir):
 
     Args:
        dir (string): name of directory to work in
-    
+
     Example:
         >>> with workdir('/temp'):
             # do something within the /temp directory
@@ -391,7 +391,7 @@ def working_directory(dir):
 
 def cmd_exists(cmd):
     return any(
-        os.access(os.path.join(path, cmd), os.X_OK) 
+        os.access(os.path.join(path, cmd), os.X_OK)
         for path in os.environ["PATH"].split(os.pathsep))
 
 
@@ -404,7 +404,7 @@ def date2jd(date):
     Returns:
         float: Julian date
      """
-    
+
     jd_td = date - datetime(2000, 1, 1, 12, 0, 0)
     jd = 2451545.0 + jd_td.days + jd_td.seconds/86400.0
     return jd
@@ -419,7 +419,7 @@ def jd2date(jd):
     Returns:
         datetime.datetime: calendar date
     """
-    
+
     mjd = jd - 2400000.5
     td = timedelta(days=mjd)
     dt = datetime(1858, 11, 17, 0, 0, 0) + td
@@ -457,11 +457,11 @@ def geterr(vec, angular=False):
         med = np.median(vec)
     else:
         med = np.median(vec)
-        
+
     s = sorted(vec)
     errlow = med - s[int(0.159*len(s))]
     errhigh = s[int(0.841*len(s))] - med
-            
+
     return med, errlow, errhigh
 
 def semi_amplitude(Msini, P, Mtotal, e, Msini_units='jupiter'):
@@ -488,7 +488,7 @@ def semi_amplitude(Msini, P, Mtotal, e, Msini_units='jupiter'):
 
     P = (P * u.d).to(u.year).value
     if Msini_units.lower() == 'jupiter':
-        pass 
+        pass
     elif Msini_units.lower() == 'earth':
         Msini = (Msini * u.M_earth).to(u.M_jup).value
     else:
@@ -503,7 +503,7 @@ def semi_major_axis(P, Mtotal):
 
     Kepler's third law
 
-    Args: 
+    Args:
         P (float): Orbital period [days]
         Mtotal (float): Mass [Msun]
 
@@ -533,7 +533,7 @@ def Msini(K, P, Mtotal, e, Msini_units='earth'):
         P (float): Orbital period [days]
         Mtotal (float): Mass of star + mass of planet [Msun]
         e (float): eccentricity
-        Msini_units (Optional[str]): Units of Msini {'earth','jupiter'} 
+        Msini_units (Optional[str]): Units of Msini {'earth','jupiter'}
             default: 'earth'
 
     Returns:
@@ -547,9 +547,9 @@ def Msini(K, P, Mtotal, e, Msini_units='earth'):
     e = np.array(e)
 
     P = (P * u.d).to(u.year).value
-    Msini = K / K_0 * np.sqrt(1.0 - e**2.0)*Mtotal**(2.0 / 3.0)*P**(1 / 3.0) 
+    Msini = K / K_0 * np.sqrt(1.0 - e**2.0)*Mtotal**(2.0 / 3.0)*P**(1 / 3.0)
     if Msini_units.lower() == 'jupiter':
-        pass 
+        pass
     elif Msini_units.lower() == 'earth':
         Msini = (Msini * u.M_jup).to(u.M_earth).value
     else:


### PR DESCRIPTION
Trailing whitespace isn't PEP8 compatible. Some text editors therefore
flag all trailing whitespace.

This commit removes all the trailing whitespace. No functionality is
affected -- this is purely to improve code readability.

(I doubt that I'm the only one who has had this annoyance when reading
through the source!)