### PR TITLE
small bugfix in Msini calculation (handles floats as well as arrays now)

### DIFF
--- a/radvel/utils.py
+++ b/radvel/utils.py
@@ -560,7 +560,7 @@ def Msini(K, P, Mstar, e, Msini_units='earth'):
     Msini = K / K_0 * np.sqrt(1.0 - e ** 2.0) * (Mstar/Msun) ** (2.0 / 3.0) * P_year ** (1 / 3.0)
 
     # Use correct calculation if any elements are >10% of the stellar mass
-    if (((Msini * u.Mjup).to(u.M_sun) / (Mstar/Msun)).value > 0.1).any():
+    if (np.array(((Msini * u.Mjup).to(u.M_sun) / (Mstar/Msun)).value > 0.1)).any():
         print("Mpsini << Mstar assumption broken, correcting Msini calculation.")
 
         a = K*(((2*(np.pi)*G)/P)**(-1/3.))*np.sqrt(1-(e**2))


### PR DESCRIPTION
a one-line bug fix that allows utils.Msini to work for float inputs now in addition to arrays.  Tested:

`In [1]: import radvel                                                                                                                         
numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject

In [2]: msini = radvel.utils.Msini(12, 11.86 * 365.25, 1.0, 0.0, Msini_units='jupiter')                                                       

In [3]: msini                                                                                                                                 
Out[3]: 0.9624724745743625

In [4]: msini = radvel.utils.Msini([12], [11.86 * 365.25], [1.0], [0.0], Msini_units='jupiter')                                               

In [5]: msini                                                                                                                                 
Out[5]: array([0.96247247])
`