### PR TITLE
Report bugfix

### DIFF
--- a/radvel/report.py
+++ b/radvel/report.py
@@ -185,6 +185,9 @@ class TexTable(RadvelReport):
         """
         Helper function to output the rows in the parameter table
         """
+        if param not in self.quantiles.keys():
+            param = param[:-1]
+
         if unit == 'radians':
             par = radvel.utils.geterr(self.report.chains[param], angular=True)
             med, low, high = par
@@ -241,14 +244,13 @@ class TexTable(RadvelReport):
                             break
                 else:
                     unit = units.get(par, '')
+
                 try:
-                    try:
-                        row = self._row(par, unit)
-                    except KeyError:
-                        row = self._row(p, unit)
-                    rows.append(row)
-                except:
-                    pass
+                    row = self._row(par, unit)
+                except KeyError:
+                    continue
+
+                rows.append(row)
 
         return rows
 

--- a/radvel/report.py
+++ b/radvel/report.py
@@ -241,12 +241,14 @@ class TexTable(RadvelReport):
                             break
                 else:
                     unit = units.get(par, '')
-
                 try:
-                    row = self._row(par, unit)
-                except KeyError:
-                    row = self._row(p, unit)
-                rows.append(row)
+                    try:
+                        row = self._row(par, unit)
+                    except KeyError:
+                        row = self._row(p, unit)
+                    rows.append(row)
+                except:
+                    pass
 
         return rows
 


### PR DESCRIPTION
Minor bugfix in report.py.  The bad behavoir was that report.py crashed when it tried to report rows that did not exist (for example, rhop_2, when there was only one transiting planet but multiple non-transiting planets).  By wrapping the row-adding logic in a try/except logic, I fixed the bug.