### PR TITLE
Version 1.2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ cache:
      - $HOME/.ccache
 
 python:
-  - "2.7"
-  - "3.6"
+  - "3.7"
 
 before_install:
     - export py="$(echo $TRAVIS_PYTHON_VERSION | head -c 1)"

--- a/radvel/__init__.py
+++ b/radvel/__init__.py
@@ -25,7 +25,7 @@ def _custom_warningfmt(msg, *a, **b):
 __all__ = ['model', 'likelihood', 'posterior', 'mcmc', 'prior', 'utils',
          'fitting', 'report', 'cli', 'driver', 'gp']
 
-__version__ = '1.2.12'
+__version__ = '1.2.13'
 __spec__ = __name__
 __package__ = __path__[0]
 

--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -394,10 +394,14 @@ def derive(args):
     post = radvel.posterior.load(status.get('fit', 'postfile'))
     chains = pd.read_csv(status.get('mcmc', 'chainfile'))
 
-    mstar = np.random.normal(
-        loc=P.stellar['mstar'], scale=P.stellar['mstar_err'],
-        size=len(chains)
-        )
+    try:
+        mstar = np.random.normal(
+            loc=P.stellar['mstar'], scale=P.stellar['mstar_err'],
+            size=len(chains)
+            )
+    except AttributeError:
+        print("Unable to calculate derived parameters, stellar parameters not defined the config file.")
+        return
 
     if (mstar <= 0.0).any():
         num_nan = np.sum(mstar <= 0.0)

--- a/radvel/prior.py
+++ b/radvel/prior.py
@@ -410,13 +410,15 @@ class NumericalPrior(Prior):
         x = []
         for param in self.param_list:
             x.append(params[param].value)
-        return np.log(self.pdf_estimate(x))
+        val = np.log(self.pdf_estimate(x))
+        return val[0]
 
     def __repr__(self):
         s = "Numerical prior on {}".format(
             self.param_list
             )
         return s
+
     def __str__(self):
         try:
             tex = model.Parameters(9).tex_labels(param_list=self.param_list)


### PR DESCRIPTION
- remove Python 2.7 tests
- catching derive without stellar parameters
- NumericalPrior return float instead of array