### PR TITLE
Version 1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ General Toolkit for Modeling Radial Velocities.
 [![Documentation Status](https://readthedocs.org/projects/radvel/badge/?version=latest)](http://radvel.readthedocs.io/en/latest/?badge=latest)
 [![PyPI version](https://badge.fury.io/py/radvel.svg)](https://badge.fury.io/py/radvel)
 [![ASCL:1801.012](https://img.shields.io/badge/ascl-1801.012-blue.svg?colorB=262255)](http://ascl.net/1801.012)
-[![Requirements Status](https://requires.io/github/California-Planet-Search/radvel/requirements.svg?branch=next-release)](https://requires.io/github/California-Planet-Search/radvel/requirements/?branch=next-release)
 
 [![Powered by emcee](https://img.shields.io/badge/powered_by-emcee-EB5368.svg?style=flat)](https://emcee.readthedocs.io)
 [![Powered by AstroPy](https://img.shields.io/badge/powered_by-AstroPy-EB5368.svg?style=flat)](http://www.astropy.org)

--- a/radvel/__init__.py
+++ b/radvel/__init__.py
@@ -25,7 +25,7 @@ def _custom_warningfmt(msg, *a, **b):
 __all__ = ['model', 'likelihood', 'posterior', 'mcmc', 'prior', 'utils',
          'fitting', 'report', 'cli', 'driver', 'gp']
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 __spec__ = __name__
 __package__ = __path__[0]
 

--- a/radvel/cli.py
+++ b/radvel/cli.py
@@ -101,14 +101,14 @@ Convergence checks will start after the minsteps threshold or the minpercent thr
                           help="Minimum percentage of steps before convergence tests are performed [5]. \
 Convergence checks will start after the minsteps threshold or the minpercent threshold has been hit."
                           )
-    psr_mcmc.add_argument('--thin', dest='thin', action='store', default=1, type=int,
-                          help="Save one sample every N steps [default=1, save all samples]"
+    psr_mcmc.add_argument('--thin', dest='thin', action='store', default=10, type=int,
+                          help="Save one sample every N steps [default=10, save every 10th sample]"
                           )
     psr_mcmc.add_argument('--serial', dest='serial', action='store', default=False, type=bool,
                           help='''If True, run MCMC in serial instead of parallel. [False]'''
                           )
-    psr_mcmc.add_argument('--save', dest='save', action='store', default=True, type=bool,
-                          help='If True, MCMC chains will be saved to be continued in a future run'
+    psr_mcmc.add_argument('--save', dest='save', action='store', default=False, type=bool,
+                          help='If True, MCMC chains will be saved to be continued in a future run [False]'
                           )
     psr_mcmc.add_argument('--proceed', dest='proceed', action='store', default=False, type=bool,
                           help='If True, MCMC chains will resume from the previous run'

--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -164,14 +164,13 @@ def mcmc(args):
         backend_loc = None
 
     status = load_status(statfile)
+    P, post = radvel.utils.initialize_posterior(config_file,
+                                                decorr=args.decorr)
 
     if status.getboolean('fit', 'run'):
         print("Loading starting positions from previous MAP fit")
 
         post = radvel.posterior.load(status.get('fit', 'postfile'))
-    else:
-        P, post = radvel.utils.initialize_posterior(config_file,
-                                                    decorr=args.decorr)
 
     msg1 = (
             "Running MCMC for {}, N_walkers = {}, N_steps = {}, N_ensembles = {}, Min Auto Factor = {}, "

--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -41,6 +41,9 @@ def plots(args):
 
     status = load_status(statfile)
 
+    P, post = radvel.utils.initialize_posterior(config_file,
+                                                decorr=args.decorr)
+
     assert status.getboolean('fit', 'run'), \
         "Must perform max-liklihood fit before plotting"
     post = radvel.posterior.load(status.get('fit', 'postfile'))
@@ -301,6 +304,9 @@ def ic_compare(args):
                             "{}_radvel.stat".format(conf_base))
 
     status = load_status(statfile)
+
+    P, post = radvel.utils.initialize_posterior(config_file,
+                                                decorr=args.decorr)
 
     assert status.getboolean('fit', 'run'), \
         "Must perform max-liklihood fit before running Information Criteria comparisons"

--- a/radvel/likelihood.py
+++ b/radvel/likelihood.py
@@ -48,7 +48,7 @@ class Likelihood(object):
             for key in keys:
                 vstr = str(self.params[key].vary)
                 if (key.startswith('tc') or key.startswith('tp')) and self.params[key].value > 1e6:
-                    par = self.params[key].value - 2450000
+                    par = self.params[key].value - self.model.time_base
                 else:
                     par = self.params[key].value
 
@@ -69,7 +69,7 @@ class Likelihood(object):
                     err = 0
                 if (key.startswith('tc') or key.startswith('tp')) and \
                         self.params[key].value > 1e6:
-                    par = self.params[key].value - 2450000
+                    par = self.params[key].value - self.model.time_base
                 else:
                     par = self.params[key].value
 

--- a/radvel/posterior.py
+++ b/radvel/posterior.py
@@ -22,6 +22,7 @@ class Posterior(Likelihood):
 
     def __init__(self,likelihood):
         self.likelihood = likelihood
+        self.model = self.likelihood.model
         self.params = likelihood.params
         self.uparams = likelihood.uparams
         self.priors = []

--- a/radvel/report.py
+++ b/radvel/report.py
@@ -380,11 +380,11 @@ Use \texttt{radvel table -t rv} to save the full \LaTeX\ table as a separate fil
                 the name of the star in the table title
         """
 
-        names = ['minafactor', 'maxarchange', 'maxgr', 'mintz']
+        names = ['minAfactor', 'maxArchange', 'maxGR', 'minTz']
         values = [self.minafactor, self.maxarchange, self.maxgr, self.mintz]
         rows = []
         for i in range(0,len(names)):
-            rows.append("$%s$ & $%s$" % (names[i], values[i]))
+            rows.append(r"%s & $%7.3f$" % (names[i], float(values[i])))
 
         kw = dict()
         kw['rows'] = rows

--- a/radvel/tests/test_api.py
+++ b/radvel/tests/test_api.py
@@ -76,13 +76,12 @@ def test_k2(setupfn='example_planets/epic203771098.py'):
 
     # set the proceed flag and continue
     args.proceed = True
-    args.nwalkers = 20
     radvel.driver.mcmc(args)
 
     args.ensembles = 1
     try:
         radvel.driver.mcmc(args)
-    except ValueError:  # expected error when changing number of ensembles
+    except ValueError:  # expected error when changing number of ensembles with proceed flag
         pass
 
     args.serial = True

--- a/radvel/tests/test_api.py
+++ b/radvel/tests/test_api.py
@@ -76,6 +76,7 @@ def test_k2(setupfn='example_planets/epic203771098.py'):
 
     # set the proceed flag and continue
     args.proceed = True
+    args.nwalkers = 20
     radvel.driver.mcmc(args)
 
     args.ensembles = 1

--- a/radvel/tests/test_api.py
+++ b/radvel/tests/test_api.py
@@ -78,6 +78,16 @@ def test_k2(setupfn='example_planets/epic203771098.py'):
     args.proceed = True
     radvel.driver.mcmc(args)
 
+    args.ensembles = 1
+    try:
+        radvel.driver.mcmc(args)
+    except ValueError:  # expected error when changing number of ensembles
+        pass
+
+    args.serial = True
+    args.proceed = False
+    radvel.driver.mcmc(args)
+
 
 def test_hd(setupfn='example_planets/HD164922.py'):
     """
@@ -86,11 +96,6 @@ def test_hd(setupfn='example_planets/HD164922.py'):
     args = _args()
     args.setupfn = setupfn
 
-    radvel.driver.fit(args)
-    radvel.driver.mcmc(args)
-
-    args.serial = True
-    args.ensembles = 1
     radvel.driver.fit(args)
     radvel.driver.mcmc(args)
 
@@ -298,11 +303,11 @@ def test_model_comp(setupfn='example_planets/HD164922.py'):
 
 if __name__ == '__main__':
     test_k2()
-    test_hd()
+    # test_hd()
     # test_proceed()
-    test_model_comp()
-    test_k2131()
-    test_celerite()
-    test_basis()
-    test_kernels()
-    test_kepler()
+    # test_model_comp()
+    # test_k2131()
+    # test_celerite()
+    # test_basis()
+    # test_kernels()
+    # test_kepler()


### PR DESCRIPTION
- changed some default convergence criteria
- fixed proceed bug
- posterior print function now subtracts time_base from time parameters instead of arbitrary offset
- fixed posterior loading bug to allow dependencies to be loaded in the setup file