### PR TITLE
update planet_parameters with change of basis

### DIFF
--- a/radvel/basis.py
+++ b/radvel/basis.py
@@ -393,6 +393,7 @@ class Basis(object):
 
         if isinstance(params_out, radvel.model.Parameters):
             params_out.basis = Basis('per tp e w k', self.num_planets)
+            params_out.planet_parameters = params_out.basis.name.split()
         return params_out
 
     def v_from_synth(self, params_in, newbasis):
@@ -727,6 +728,7 @@ class Basis(object):
                 self.params = newbasis.split()
 
         params_out.basis = Basis(newbasis, self.num_planets)
+        params_out.planet_parameters = params_out.basis.name.split()
 
         return params_out
 


### PR DESCRIPTION
Make sure that the `planet_parameters` attribute of a Parameters instance matches the chosen basis even after transforming.

This is a fix to the following bug:

```
params = radvel.model.Parameters(2, basis='per tp e w k')
# set some parameter values here
synth_basis = radvel.basis.Basis(params.basis.name, params.num_planets)
mcmc_params = synth_basis.from_synth(params, 'logper tc secosw sesinw logk', keep=False)
print(mcmc_params.planet_parameters)
```

would formerly return the old basis (`per tp e w k`) instead of the updated basis (`logper tc secosw sesinw logk`).
(At least I think that's a bug -- unless I'm misunderstanding the desired behavior?)