### PR TITLE
Orbit plots leave posterior object in an inconsistent state

### DIFF
--- a/radvel/plot/orbit_plots.py
+++ b/radvel/plot/orbit_plots.py
@@ -103,7 +103,8 @@ class MultipanelPlot(object):
 
         # convert params to synth basis
         synthparams = self.post.params.basis.to_synth(self.post.params)
-        self.post.params.update(synthparams)
+        self.post.params = synthparams
+        self.post.vector.dict_to_vector()
 
         self.model = self.post.likelihood.model
         self.rvtimes = self.post.likelihood.x

--- a/radvel/plot/orbit_plots.py
+++ b/radvel/plot/orbit_plots.py
@@ -4,6 +4,7 @@ from matplotlib import rcParams, gridspec
 from matplotlib import pyplot as pl
 from matplotlib.ticker import MaxNLocator
 from astropy.time import Time
+import copy
 
 import radvel
 from radvel import plot
@@ -65,7 +66,7 @@ class MultipanelPlot(object):
                  figwidth=7.5, fit_linewidth=2.0, set_xlim=None, text_size=9, highlight_last=False,
                  show_rms=False, legend_kwargs=dict(loc='best'), status=None):
 
-        self.post = post
+        self.post = copy.deepcopy(post)
         self.saveplot = saveplot
         self.epoch = epoch
         self.yscale_auto = yscale_auto


### PR DESCRIPTION
It took me a while to figure out what was going on here, but it turns out that `MultiPanelPlot()` changes the parameter basis to the synth basis without changing the basis name and updating the vector object. When I subsequently printed the posterior object, the posterior `__repr__()` method would call `self.vector.dict_to_vector()` and overwrite parameter values with the wrong numbers (in my particular case, e1=secosw1, w1=sesinw1, and tp1=tc1).

My proposed solution is (1) to properly update the parameter basis and vector object in the plotting routine and (2) take a deepcopy of the posterior object when plotting, such that the plot does not modify the input posterior object.

I hope this is useful!

All the best,
René