### PR TITLE
Fixing typo in 'Introduction to Autocorr Times'

### DIFF
--- a/docs/autocorrintro.rst
+++ b/docs/autocorrintro.rst
@@ -36,7 +36,7 @@ using the ``minAfactor`` argument when calling the MCMC.
 
 The autocorrelation factor is calculated for each parameter and the minimum of these values
 is returned in real time as the MCMC run progresses.
-Once the minimum autocorrelation factor is below ``minAfactor``, this criterion
+Once the minimum autocorrelation factor is above ``minAfactor``, this criterion
 for convergence is met. Whether or not ``minAfactor`` has been satisfied can be seen in the autocorrelation plot below. Once the
 maximum autocorrelation time has passed the dashed line labeled 'Autocorrelation Factor Criterion,' the chain is likely converged. After five consecutive status checks appear past the dashed line, the MCMC will halt if all other criterion have also been met.
 


### PR DESCRIPTION
Page originally said that convergence criterion were met after the minimum autocorrelation factor was below ``minAfactor`` but has been edited to state above instead. Resolves typo mentioned in Issue #332.