### PR TITLE
Fix Vector Initialization

### DIFF
--- a/radvel/model.py
+++ b/radvel/model.py
@@ -229,7 +229,7 @@ class Vector(object):
         self.vector = vector
 
     def vector_names(self):
-        names = [0] * (len(self.params.keys()))
+        names = [0] * (len(self.params.keys()) + 2)
         for key in self.params.keys():
             try:
                 names[self.indices[key]] = key

--- a/radvel/model.py
+++ b/radvel/model.py
@@ -235,7 +235,7 @@ class Vector(object):
                 names[self.indices[key]] = key
             except KeyError:
                 pass
-        self.names = names
+        self.names = [i for i in names if type(i) == str]
 
     def vector_to_dict(self):
         for key in self.params.keys():


### PR DESCRIPTION
The vector.names attribute was not long enough when initialized, raising an indexing error. This should resolve Issue #333.