### PR TITLE
Fix eccentricity prior when num_planets is a list

### DIFF
--- a/radvel/prior.py
+++ b/radvel/prior.py
@@ -89,10 +89,10 @@ class EccentricityPrior(Prior):
 
         if type(num_planets) == int:
             self.planet_list = range(1, num_planets+1)
-            npl = len(self.planet_list)
+            npl = num_planets
         else:
             self.planet_list = num_planets
-            npl = num_planets
+            npl = len(self.planet_list)
 
         if type(upperlims) == float:
             self.upperlims = [upperlims] * npl

--- a/radvel/tests/test_api.py
+++ b/radvel/tests/test_api.py
@@ -251,6 +251,7 @@ def test_priors():
 
     prior_tests = {
         radvel.prior.EccentricityPrior(1):                  1/.99,
+        radvel.prior.EccentricityPrior([1]):                1/.99,
         radvel.prior.PositiveKPrior(1):                     1.0,
         radvel.prior.Gaussian('per1', 9.9, 0.1):            scipy.stats.norm(9.9,0.1).pdf(10.),
         radvel.prior.HardBounds('per1', 1.0, 9.0):          0.,


### PR DESCRIPTION
This fixes #347 by ensuring that `npl`, the variable used to make `upperlims` a list, is always an integer. If `num_planets` is a list and `upperlims` is a float, the length of `num_planets` is used to make a `upperlims` a list. The issue was that `npl` was set to the list itself when `num_planets` was a list, but was treated as an integer in the multiplication to make the `upperlims` list.