### PR TITLE
Report fix

### DIFF
--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -570,7 +570,8 @@ def report(args):
                             "{}_radvel.stat".format(conf_base))
 
     status = load_status(statfile)
-    status['ic_compare']['ic'] = status['ic_compare']['ic'].replace('-inf', '-np.inf')
+    if 'ic_compare' in status.keys():
+        status['ic_compare']['ic'] = status['ic_compare']['ic'].replace('-inf', '-np.inf')
 
     P, post = radvel.utils.initialize_posterior(config_file)
     post = radvel.posterior.load(status.get('fit', 'postfile'))

--- a/radvel/driver.py
+++ b/radvel/driver.py
@@ -570,6 +570,7 @@ def report(args):
                             "{}_radvel.stat".format(conf_base))
 
     status = load_status(statfile)
+    status['ic_compare']['ic'] = status['ic_compare']['ic'].replace('-inf', '-np.inf')
 
     P, post = radvel.utils.initialize_posterior(config_file)
     post = radvel.posterior.load(status.get('fit', 'postfile'))


### PR DESCRIPTION
Some models have likelihoods of 0 at machine precision. Their assigned log-likelihood is -np.inf, but str(-np.inf) is "-inf". When the radvel.driver.report() function evaluates this string using eval(), it finds that -inf is not defined. The resulting error aborts the model comparison table entirely. I used a simple replacement in report() to replace all instances of "-inf" with "-np.inf" in the radvel stat file just before it is evaluated:

status['ic_compare']['ic'] = status['ic_compare']['ic'].replace('-inf', '-np.inf')