### PR TITLE
Fix for Cython installation issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "pybind11", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,7 @@
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext as _build_ext
 import re
-
-
-class build_ext(_build_ext):
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
-
+import numpy
 
 def get_property(prop, project):
     result = re.search(r'{}\s*=\s*[\'"]([^\'"]*)[\'"]'.format(prop),
@@ -18,7 +9,11 @@ def get_property(prop, project):
     return result.group(1)
 
 
-extensions = [Extension("radvel._kepler", ["src/_kepler.pyx"],)]
+extensions = [
+    Extension(
+        "radvel._kepler", ["src/_kepler.pyx"],
+        include_dirs=[numpy.get_include()])    
+]
 
 reqs = []
 for line in open('requirements.txt', 'r').readlines():
@@ -32,7 +27,6 @@ setup(
     packages=find_packages(),
     setup_requires=['numpy', 'cython'],
     ext_modules=extensions,
-    cmdclass={'build_ext': build_ext},
     data_files=[
         (
             'radvel_example_data', 


### PR DESCRIPTION
I added a `pyproject.toml` file (see [here](https://stackoverflow.com/a/62983901/12777008) for brief explanation) to ensure `Cython` gets installed before the `radvel` project gets installed/built. If this is not ensured, the installation might fail as several people have noticed before (https://github.com/California-Planet-Search/radvel/issues/375, https://github.com/California-Planet-Search/radvel/issues/237). 

I verified that the installation works without `Cython` pre-installed using a `conda` environment with just the base Python installation by running a local install using `pip install -e .`.

I also encountered an error with `numpy` that has already been mentioned in pull request https://github.com/California-Planet-Search/radvel/pull/377.  The `setup.py` was changed to provide a fix for this issue.

The current setup uses a minimal `pyproject.toml` and should probably be adapted according to the specification given [here](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).