### PR TITLE
v1.5.6: Fix cibuildwheel rate limiting for macOS/Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - name: Pre-cache virtualenv for cibuildwheel
+      shell: bash
+      run: |
+        pip install virtualenv
+        VENV_VERSION=$(python -c "import virtualenv; print(virtualenv.__version__)")
+        echo "virtualenv version: $VENV_VERSION"
+
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.22
       env:
@@ -91,6 +103,7 @@ jobs:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_BUILD: pip install Cython numpy setuptools
         CIBW_TEST_SKIP: "*"
+        CIBW_DEPENDENCY_VERSIONS: latest
 
     - uses: actions/upload-artifact@v4
       with:

--- a/radvel/__init__.py
+++ b/radvel/__init__.py
@@ -29,7 +29,7 @@ def _custom_warningfmt(msg, *a, **b):
 __all__ = ['model', 'likelihood', 'posterior', 'mcmc', 'prior', 'utils',
          'fitting', 'report', 'cli', 'driver', 'gp', 'nested_sampling']
 
-__version__ = '1.5.5'
+__version__ = '1.5.6'
 __package__ = __path__[0]
 
 MODULEDIR, filename = os.path.split(__file__)


### PR DESCRIPTION
## Summary
- Fix cibuildwheel failing on macOS and Windows due to GitHub API rate limiting (HTTP 429)
  - Set `CIBW_DEPENDENCY_VERSIONS=latest` to install build tools from PyPI instead of GitHub blob URLs
  - Pre-install virtualenv before running cibuildwheel
- Bump version to 1.5.6

## Test plan
- [ ] CI tests pass on all Python versions
- [ ] After merge, create v1.5.6 release and verify wheel builds succeed on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)