### PR TITLE
Fix Coveralls upload failing on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,11 @@ jobs:
         pytest radvel --cov=radvel --cov-report=term-missing -v --tb=long
 
     - name: Upload coverage to Coveralls
-      if: matrix.python-version == '3.9'
+      if: matrix.python-version == '3.9' && github.actor != 'dependabot[bot]'
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      continue-on-error: true
       run: |
         coverage xml
         coveralls

--- a/radvel/__init__.py
+++ b/radvel/__init__.py
@@ -29,7 +29,7 @@ def _custom_warningfmt(msg, *a, **b):
 __all__ = ['model', 'likelihood', 'posterior', 'mcmc', 'prior', 'utils',
          'fitting', 'report', 'cli', 'driver', 'gp', 'nested_sampling']
 
-__version__ = '1.5.6'
+__version__ = '1.5.7'
 __package__ = __path__[0]
 
 MODULEDIR, filename = os.path.split(__file__)


### PR DESCRIPTION
## Summary

- Dependabot PRs cannot access `secrets.COVERALLS_REPO_TOKEN`, so the post-test "Upload coverage to Coveralls" step in the Python 3.9 job dies with `CoverallsException: GITHUB_TOKEN is not set` even though every test passes (see [PR #417](https://github.com/California-Planet-Search/radvel/pull/417) failure).
- Skips the Coveralls step on Dependabot PRs, passes `GITHUB_TOKEN` (which the coveralls library auto-detects when running in Actions) on normal runs, and marks the step `continue-on-error: true` so a coverage-upload hiccup can never block CI again.
- Bumps version 1.5.6 → 1.5.7 (next-release was at parity with master).

## Test plan

- [ ] Watch this PR's CI: all four `test (3.9|3.11|3.12|3.13)` jobs go green.
- [ ] After merge, comment `@dependabot rebase` on PR #417 and confirm its 3.9 check passes.
- [ ] On the next push to `next-release`/`master` from a maintainer, confirm Coveralls upload still succeeds (token path unchanged for non-Dependabot runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)