### PR TITLE
v1.6 M6: Multi-arch GHCR publish on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Docker (multi-arch publish)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/california-planet-search/radvel-api
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Build and push (linux/amd64,linux/arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Final v1.6 milestone: a release-triggered workflow that publishes the radvel-api Docker image to GHCR for both linux/amd64 and linux/arm64.

- **`.github/workflows/docker.yml`** — runs on every published GitHub release (and manually via `workflow_dispatch` for dry-runs).
- Logs into GHCR using the workflow's auto-provisioned `GITHUB_TOKEN` (no extra secrets to provision).
- Tags via `docker/metadata-action`: `1.6.0`, `1.6`, `latest` (default branch only), and `sha-<short>`.
- Builds both architectures via QEMU + buildx with GHA cache so the arm64 build under emulation stays inside the runner timeout budget.

## How to cut the release

1. Merge this PR.
2. Tag `v1.6.0` from `master` after the maintainers' usual `next-release → master` merge.
3. Publish a GitHub release pointing at the tag.
4. CI fans out: `build-wheels` + `build-sdist` + `publish` push the Python distribution to PyPI; `docker.yml` pushes the multi-arch image to `ghcr.io/california-planet-search/radvel-api`.

## Test plan
- [ ] CI green (the workflow itself doesn't run on PR — only on `release: published` or manual trigger).
- [ ] After tagging v1.6.0: `docker pull ghcr.io/california-planet-search/radvel-api:1.6.0` succeeds for both architectures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)