### PR TITLE
Release v1.6.1: macos-13 matrix drop + cross-compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -194,6 +194,10 @@ jobs:
         CIBW_BEFORE_BUILD: pip install Cython numpy setuptools
         CIBW_TEST_SKIP: "*"
         CIBW_DEPENDENCY_VERSIONS: latest
+        # macos-13 (Intel) runners almost never get picked up on free-tier
+        # OSS, so build both arm64 and x86_64 wheels from the macos-14 ARM
+        # runner via cibuildwheel's cross-compile path.
+        CIBW_ARCHS_MACOS: arm64 x86_64
 
     - uses: actions/upload-artifact@v4
       with:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+1.6.1 (2026-05-14)
+------------------
+
+- Re-cut release. The v1.6.0 release tag exists on GitHub and GHCR
+  (``ghcr.io/california-planet-search/radvel-api:1.6.0``) but never
+  reached PyPI because the ``build-wheels (macos-13)`` job sat queued
+  for 19+ hours on GitHub's effectively-unavailable Intel macOS
+  runners. v1.6.1 drops ``macos-13`` from the matrix and
+  cross-compiles x86_64 macOS wheels from the ``macos-14`` ARM
+  runner via cibuildwheel's ``CIBW_ARCHS_MACOS=arm64 x86_64`` — same
+  wheel coverage, no dependence on Intel runners.
+
 1.6.0 (2026-05-11)
 ------------------
 

--- a/radvel/__init__.py
+++ b/radvel/__init__.py
@@ -29,7 +29,7 @@ def _custom_warningfmt(msg: str, *a: object, **b: object) -> str:
 __all__ = ['model', 'likelihood', 'posterior', 'mcmc', 'prior', 'utils',
          'fitting', 'report', 'cli', 'driver', 'gp', 'nested_sampling']
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 __package__ = __path__[0]
 
 MODULEDIR, filename = os.path.split(__file__)


### PR DESCRIPTION
## Summary

- Drops `macos-13` from the wheel build matrix (Intel macOS runners on free-tier OSS are unavailable — v1.6.0 queued 19h+ and was cancelled before pickup)
- Cross-compiles x86_64 macOS wheels from the `macos-14` ARM runner via `CIBW_ARCHS_MACOS=arm64 x86_64`
- Bumps version to 1.6.1

## Test plan

- [x] CI green on next-release HEAD (run 25876583428)
- [ ] On release, verify `build-wheels (macos-14)` produces both arm64 and x86_64 wheels
- [ ] On release, verify `publish` job runs and uploads to PyPI
- [ ] `pip install radvel==1.6.1` works on Intel mac (via cross-compiled wheel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)